### PR TITLE
lmp/build.sh: publish only compressed wic files

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -34,6 +34,8 @@ DEPLOY_DIR_IMAGE=$(cat build/image_dir)
 
 # Prepare files to publish
 rm -f ${DEPLOY_DIR_IMAGE}/*.txt
+## Only publish wic.gz
+rm -f ${DEPLOY_DIR_IMAGE}/*.wic
 
 # FIXME: Sparse images here, until it gets done by OE
 case "${MACHINE}" in


### PR DESCRIPTION
Build system is now creating both wic and wic.gz image files so change
build.sh to publish only the compressed version.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>