### PR TITLE
lmp/jobserv: add builds for qemuarm64

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -93,6 +93,7 @@ triggers:
               - colibri-imx7
               - cubox-i
               - hikey960
+              - qemuarm64
         params:
           IMAGE: lmp-gateway-image
           OSTREE_BRANCHNAME: lmp
@@ -172,6 +173,7 @@ triggers:
               - colibri-imx7
               - cubox-i
               - hikey960
+              - qemuarm64
         params:
           IMAGE: lmp-gateway-image
           OSTREE_BRANCHNAME: lmp-premerge


### PR DESCRIPTION
qemuarm64 is now supported in LmP.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>