### PR TITLE
zephyr/jobserv: fix 840dk sanity worker tag

### DIFF
--- a/zephyr/jobserv.yml
+++ b/zephyr/jobserv.yml
@@ -72,7 +72,7 @@ triggers:
         container: zephyrprojectrtos/zephyr-build
         container-user: root
         container-entrypoint: ""
-        host-tag: zephyr-nrf52840_pca10056
+        host-tag: zephyr-nrf52840-pca10056
         privileged: true
         params:
           PYOCD_BOARD_NAME: nRF52840-DK


### PR DESCRIPTION
The underscore is causing issues, so replace it with a dash:
zephyr-nrf52840-pca10056

Signed-off-by: Michael Scott <mike@foundries.io>