### PR TITLE
zephyr/sanity-device: always use pyocd to flash sanity tests

### DIFF
--- a/zephyr/sanity-device.sh
+++ b/zephyr/sanity-device.sh
@@ -56,7 +56,7 @@ sanitycheck  \
 	--test-only \
 	--device-testing \
 	--device-serial $board_tty \
-	--west-flash=--board-id=$board_uid \
+	--west-flash="-r pyocd --board-id=$board_uid" \
 	-e kernel \
 || true
 


### PR DESCRIPTION
PyOCD is the only runner that we support for sanity flashing.  Let's
make sure we use it.

Signed-off-by: Michael Scott <mike@foundries.io>