### PR TITLE
zephyr/sanity-device: use --west-runner to specify pyocd

### DIFF
--- a/zephyr/sanity-device.sh
+++ b/zephyr/sanity-device.sh
@@ -56,7 +56,8 @@ sanitycheck  \
 	--test-only \
 	--device-testing \
 	--device-serial $board_tty \
-	--west-flash="-r pyocd --board-id=$board_uid" \
+	--west-flash=--board-id=$board_uid \
+	--west-runner=pyocd \
 	-e kernel \
 || true
 


### PR DESCRIPTION
We still only support pyocd, but we need a better way to set the
runner.  Using custom parameter: --west-runner.

Signed-off-by: Michael Scott <mike@foundries.io>