### PR TITLE
zephyr/jobserv: extend timeout to 60

### DIFF
--- a/zephyr/jobserv.yml
+++ b/zephyr/jobserv.yml
@@ -1,4 +1,4 @@
-timeout: 30   # the qemu testing can take some time
+timeout: 60   # the qemu testing can take some time
 email:
   users: 'ci-notifications@foundries.io'
 triggers:


### PR DESCRIPTION
Signed-off-by: Michael Scott <mike@foundries.io>