### PR TITLE
zephyr/jobserv: mark some more tests as flaky

### DIFF
--- a/zephyr/jobserv.yml
+++ b/zephyr/jobserv.yml
@@ -84,10 +84,16 @@ triggers:
 params:
   archive: /archive
   FLAKY_TESTS: |
+    samples/drivers/led_lp5562
+    samples/subsys/usb/cdc_acm
+    samples/subsys/usb/cdc_acm_composite
+    samples/subsys/usb/dfu
+    samples/subsys/usb/testusb
     tests/benchmarks/sched
     tests/kernel/interrupt
     tests/kernel/sched/schedule_api
     tests/kernel/mem_slab/mslab_threadsafe
+    tests/subsys/fs/nffs_fs_api/large
 
 script-repos:
   fio:


### PR DESCRIPTION
With the switch to nRF52840-DK, we've noticed several tests failing
in sanitycheck.  Most of these are due to specific needs for these
tests.  IE: the USB tests require that the nRF USB be connected during
testing, the led_lp5562 test requires a specific LED be connected via
I2C, etc.

The exception to this is the nffs_fs_api/large test, which needs more
investigation, but is also not working upstream.

Signed-off-by: Michael Scott <mike@foundries.io>