### PR TITLE
Add scripts for "factory containers"

### DIFF
--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -e
+# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: Apache-2.0
 set -o pipefail
 
 HERE=$(dirname $(readlink -f $0))

--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -1,0 +1,108 @@
+#!/bin/sh -e
+set -o pipefail
+
+HERE=$(dirname $(readlink -f $0))
+source $HERE/../helpers.sh
+
+require_params FACTORY
+
+run apk --no-cache add file git
+
+ARCH=amd64
+file /bin/busybox | grep -q aarch64 && ARCH=arm64 || true
+file /bin/busybox | grep -q armhf && ARCH=arm || true
+
+manifest_arch=$ARCH
+[ $manifest_arch = "arm" ] && manifest_arch=armv6
+status Grabbing manifest-tool for $manifest_arch
+wget -O /bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.8.0/manifest-tool-linux-$manifest_arch
+chmod +x /bin/manifest-tool
+
+if [ -z "$IMAGES" ] ; then
+	if [ -z "$CLEAN_BUILD" ] ; then
+		IMAGES=$(find * -prune -type d)
+	else
+		# Only build images when their files change
+		IMAGES=$(git diff --name-only $GIT_OLD_SHA..$GIT_SHA | cut -d "/" -f1 | sort -u)
+	fi
+fi
+
+/usr/local/bin/dockerd-entrypoint.sh --raw-logs >$archive/dockerd.log 2>&1 &
+for i in `seq 10` ; do
+	sleep 1
+	docker info >/dev/null 2>&1 && break
+	if [ $i = 10 ] ; then
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+done
+
+TAG=${GIT_SHA:0:6}
+
+if [ -f /secrets/osftok ] ; then
+	mkdir -p $HOME/.docker
+fi
+
+echo '<testsuite name="unit-tests">' > /archive/junit.xml
+trap 'echo "</testsuite>" >> /archive/junit.xml' TERM INT EXIT
+
+for x in $IMAGES ; do
+	unset SKIP_ARCHS MANIFEST_PLATFORMS EXTRA_TAGS_$ARCH TEST_CMD
+	conf=$x/docker-build.conf
+	if [ -f $conf ] ; then
+		echo "Sourcing docker-build.conf for build rules in $x"
+		. $conf
+	fi
+
+	# check to see if we should skip building this image`
+	found=0
+	for a in $SKIP_ARCHS ; do
+		if [ "$a" = "$ARCH" ] ; then
+			status "Skipping build of $x on $ARCH"
+			found=1
+			break
+		fi
+	done
+	[ $found -eq 1 ] && continue
+
+	# allow the docker-build.conf to override our manifest platforms
+	MANIFEST_PLATFORMS="${MANIFEST_PLATFORMS-linux/amd64,linux/arm,linux/arm64}"
+
+	status Building docker image $x for $ARCH
+	cd $x
+	ct_base="hub.foundries.io/${FACTORY}/$x"
+	run docker build -t ${ct_base}:$TAG-$ARCH --force-rm .
+	if [ -f /secrets/osftok ] ; then
+		status "Doing docker-login to hub.foundries.io with secret"
+		docker login hub.foundries.io --username=doesntmatter --password=$(cat /secrets/osftok) | indent
+		# do a quick sanity check to make sure we are logged in
+		run docker pull ${ct_base} || echo "WARNING - docker pull failed, is this a new container image?"
+
+		run docker push ${ct_base}:$TAG-$ARCH
+
+		run manifest-tool push from-args \
+			--platforms $MANIFEST_PLATFORMS \
+			--template ${ct_base}:$TAG-ARCH \
+			--target ${ct_base}:$TAG || true
+		run manifest-tool push from-args \
+			--platforms $MANIFEST_PLATFORMS \
+			--template ${ct_base}:$TAG-ARCH \
+			--target ${ct_base}:latest || true
+	else
+		echo "osftoken not provided, skipping publishing step"
+	fi
+
+	if [ -n "$TEST_CMD" ] ; then
+		status Running test command inside container: $TEST_CMD
+		echo "<testcase name=\"test-$x\">" >> /archive/junit.xml
+		echo "   docker run --rm --entrypoint=\"\" ${ct_base}:$TAG-$ARCH $TEST_CMD"
+		if ! docker run --rm --entrypoint="" ${ct_base}:$TAG-$ARCH $TEST_CMD > /archive/$x-test.log 2>&1 ; then
+			status "Testing for $x failed"
+			echo "<failure>" >> /archive/junit.xml
+			cat /archive/$x-test.log | sed -e 's/</\&lt;/g' -e 's/>/\&gt;/g' >> /archive/junit.xml
+			echo "</failure>" >> /archive/junit.xml
+		fi
+		echo "</testcase>" >> /archive/junit.xml
+	fi
+	cd ..
+done

--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -2,7 +2,7 @@
 set -o pipefail
 
 HERE=$(dirname $(readlink -f $0))
-source $HERE/../helpers.sh
+. $HERE/../helpers.sh
 
 require_params FACTORY
 
@@ -37,7 +37,7 @@ for i in `seq 10` ; do
 	fi
 done
 
-TAG=${GIT_SHA:0:6}
+TAG=$(git log -1 --format=%h)
 
 if [ -f /secrets/osftok ] ; then
 	mkdir -p $HOME/.docker

--- a/factory-containers/docker-app-publish.sh
+++ b/factory-containers/docker-app-publish.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+set -o pipefail
+
+HERE=$(dirname $(readlink -f $0))
+source $HERE/../helpers.sh
+
+require_params FACTORY
+
+CREDENTIALS=/var/cache/bitbake/credentials.zip
+TAG=${GIT_SHA:0:6}
+
+tufrepo=$(mktemp -u -d)
+
+run garage-sign init --repo ${tufrepo} --credentials ${CREDENTIALS}
+run garage-sign targets pull --repo ${tufrepo}
+
+sha=$(sha256sum ${tufrepo}/roles/unsigned/targets.json)
+apps=$(ls *.dockerapp)
+for app in $apps ; do
+	sed -i ${app} -e "s/image: hub.foundries.io\/${FACTORY}\/\(.*\):latest/image: hub.foundries.io\/${FACTORY}\/\1:$TAG/g"
+	run ${HERE}/ota-dockerapp.py publish ${app} ${CREDENTIALS} ${H_BUILD} ${tufrepo}/roles/unsigned/targets.json
+done
+
+newsha=$(sha256sum ${tufrepo}/roles/unsigned/targets.json)
+if [[ "$sha" = "$newsha" ]] && [[ -n "$apps" ]] ; then
+	# there are two outcomes when pushing apps:
+	# 1) the repo has online keys and the targets.json on the server was
+	#    updated
+	# 2) we have offline keys, and the script updated the local copy
+	#    of targets.json
+	# If we are here, #1 happened and we need to pull in the new version
+	# of targets.json
+	echo "Pulling updated TUF targets from the remote TUF repository"
+	run garage-sign targets pull --repo ${tufrepo}
+fi
+
+run ${HERE}/ota-dockerapp.py add-build ${CREDENTIALS} ${H_BUILD} ${tufrepo}/roles/unsigned/targets.json `ls *.dockerapp`
+
+echo "Signing local TUF targets"
+run garage-sign targets sign --repo ${tufrepo} --key-name targets
+
+echo "Publishing local TUF targets to the remote TUF repository"
+run garage-sign targets push --repo ${tufrepo}

--- a/factory-containers/docker-app-publish.sh
+++ b/factory-containers/docker-app-publish.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -e
+# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: Apache-2.0
 set -o pipefail
 
 HERE=$(dirname $(readlink -f $0))

--- a/factory-containers/docker-app-publish.sh
+++ b/factory-containers/docker-app-publish.sh
@@ -7,6 +7,8 @@ HERE=$(dirname $(readlink -f $0))
 
 require_params FACTORY
 
+run apk --no-cache add git
+
 CREDENTIALS=/var/cache/bitbake/credentials.zip
 TAG=$(git log -1 --format=%h)
 

--- a/factory-containers/docker-app-publish.sh
+++ b/factory-containers/docker-app-publish.sh
@@ -2,12 +2,12 @@
 set -o pipefail
 
 HERE=$(dirname $(readlink -f $0))
-source $HERE/../helpers.sh
+. $HERE/../helpers.sh
 
 require_params FACTORY
 
 CREDENTIALS=/var/cache/bitbake/credentials.zip
-TAG=${GIT_SHA:0:6}
+TAG=$(git log -1 --format=%h)
 
 tufrepo=$(mktemp -u -d)
 
@@ -22,7 +22,7 @@ for app in $apps ; do
 done
 
 newsha=$(sha256sum ${tufrepo}/roles/unsigned/targets.json)
-if [[ "$sha" = "$newsha" ]] && [[ -n "$apps" ]] ; then
+if [ "$sha" = "$newsha" ] && [ -n "$apps" ] ; then
 	# there are two outcomes when pushing apps:
 	# 1) the repo has online keys and the targets.json on the server was
 	#    updated

--- a/factory-containers/ota-dockerapp.py
+++ b/factory-containers/ota-dockerapp.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2019 Foundries.io
+# SPDX-License-Identifier: Apache-2.0
+#
+import argparse
+import hashlib
+import json
+import os
+import sys
+
+from datetime import datetime
+from zipfile import ZipFile
+
+import logging
+
+import requests
+
+logging.basicConfig(level='INFO')
+
+
+class NullAuth(requests.auth.AuthBase):
+    '''force requests to ignore the ``.netrc``
+
+    JobServ will create a .netrc token for users needing to access the
+    Run. This tells requests not to use that, and instead use the oauth
+    token we create.
+    '''
+
+    def __call__(self, r):
+        return r
+
+
+def get_token(oauth_server, client, secret):
+    data = {'grant_type': 'client_credentials'}
+    url = oauth_server
+    if url[-1] != '/':
+        url += '/'
+    url += 'token'
+    r = requests.post(url, data=data, auth=(client, secret))
+    r.raise_for_status()
+    return r.json()['access_token']
+
+
+def add_target(targets_json, app, version, content):
+    with open(args.targets_json) as f:
+        data = json.load(f)
+
+    now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    content = content.encode()
+    m = hashlib.sha256()
+    m.update(content)
+    data['targets'][app + '-' + version] = {
+        'hashes': {'sha256': m.hexdigest()},
+        'length': len(content),
+        'custom': {
+            'targetFormat': 'BINARY',
+            'version': version,
+            'name': app,
+            'hardwareIds': ['all'],
+            'createdAt': now,
+            'updatedAt': now,
+        },
+    }
+    with open(args.targets_json, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def publish(args):
+    with ZipFile(args.credentials) as zf:
+        with zf.open('tufrepo.url') as f:
+            repourl = f.read().strip().decode()
+
+        with zf.open('treehub.json') as f:
+            oauth2 = json.load(f).get('oauth2')
+
+    if repourl[-1] != '/':
+        repourl += '/'
+
+    token = ''
+    if oauth2:
+        token = get_token(
+            oauth2['server'], oauth2['client_id'], oauth2['client_secret'])
+
+    app = os.path.basename(args.dockerapp.name)
+    url = repourl + 'api/v1/user_repo/targets/' + app + '-' + args.version
+    r = requests.put(url,
+                     params={'name': app, 'version': args.version},
+                     files={'file': ('filename', args.dockerapp)},
+                     headers={'Authorization': 'Bearer ' + token},
+                     auth=NullAuth())
+    if r.status_code == 412:
+        print('OTA reposerver has offline keys, using: ' + args.targets_json)
+        os.lseek(args.dockerapp.fileno(), 0, 0)
+        add_target(args.targets_json, app, args.version, args.dockerapp.read())
+    elif r.status_code != 200:
+        sys.exit('Unable to create %s: HTTP_%d\n%s' % (
+            url, r.status_code, r.text))
+
+
+def add_build(args):
+    latest = {}
+    with open(args.targets_json) as f:
+        data = json.load(f)
+        for name, target in data['targets'].items():
+            if target['custom']['targetFormat'] == 'OSTREE':
+                hwid = target['custom']['hardwareIds'][0]
+                cur = latest.get(hwid)
+                ver = int(target['custom']['version'])
+                if not cur or int(cur['custom']['version']) < ver:
+                    latest[hwid] = target
+    logging.info('Latest targets: %r', latest)
+    for target in latest.values():
+        apps = {}
+        target['custom']['docker_apps'] = apps
+        for app in args.apps:
+            filename = os.path.basename(app) + '-' + args.version
+            apps[app] = {'filename': filename}
+    logging.info('Latest targets with apps: %r', latest)
+    with open(args.targets_json, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        'Manage dockerapps on the OTA Connect reposerver')
+
+    cmds = parser.add_subparsers(title='Commands')
+
+    p = cmds.add_parser('publish')
+    p.set_defaults(func=publish)
+    p.add_argument('dockerapp', type=argparse.FileType('r'))
+    p.add_argument('credentials', type=argparse.FileType('rb'))
+    p.add_argument('version')
+    p.add_argument('targets_json')
+
+    p = cmds.add_parser('add-build')
+    p.set_defaults(func=add_build)
+    p.add_argument('credentials', type=argparse.FileType('rb'))
+    p.add_argument('version')
+    p.add_argument('targets_json')
+    p.add_argument('apps', nargs='+')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = get_args()
+    if getattr(args, 'func', None):
+        args.func(args)

--- a/factory-containers/test_build.sh
+++ b/factory-containers/test_build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+HERE=$(dirname $(readlink -f $0))
+TMPDIR=${TMPDIR-/tmp}
+
+tmpdir=$(mktemp -p $TMPDIR -d test_build.XXXX)
+trap "echo removing tempdir; rm -rf $tmpdir" TERM INT EXIT
+
+git clone https://github.com/foundriesio/gateway-containers $tmpdir
+cd $tmpdir
+
+parent=$(dirname $HERE)
+docker run --rm --privileged -it -w $PWD \
+	-v $PWD:/archive \
+	-v $PWD:$PWD \
+	-v $parent:$parent \
+	-e FACTORY=test-value \
+	-e IMAGES=mosquitto \
+	-e GIT_SHA=unit_test \
+	docker:dind $HERE/build.sh
+
+echo "Junit Results"
+cat $tmpdir/junit.xml

--- a/factory-containers/test_build.sh
+++ b/factory-containers/test_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
 HERE=$(dirname $(readlink -f $0))
 TMPDIR=${TMPDIR-/tmp}

--- a/factory-containers/test_build.sh
+++ b/factory-containers/test_build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -eu
+# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: Apache-2.0
 
 HERE=$(dirname $(readlink -f $0))
 TMPDIR=${TMPDIR-/tmp}


### PR DESCRIPTION
These are the scripts I've been using for building multi-arch containers in CI and then having their corresponding docker-app(s) published into an OTA targets.json.