### PR TITLE
lmp: Add ability to add docker-apps into build

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -19,6 +19,7 @@ OSTREE_BRANCHNAME = "${MACHINE}-${OSTREE_BRANCHNAME}"
 GARAGE_SIGN_REPO = "/tmp/garage_sign_repo"
 GARAGE_TARGET_VERSION = "${H_BUILD}"
 GARAGE_TARGET_URL = "https://ci.foundries.io/projects/${H_PROJECT}/builds/${H_BUILD}"
+GARAGE_CUSTOMIZE_TARGET = "${HERE}/copy-previous-dockerapps"
 EOFEOF
 
 if [ -z "$SOTA_PACKED_CREDENTIALS" ] || [ ! -f $SOTA_PACKED_CREDENTIALS ] ; then

--- a/lmp/copy-previous-dockerapps
+++ b/lmp/copy-previous-dockerapps
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2019 Foundries.io
+# SPDX-License-Identifier: Apache-2.0
+#
+import argparse
+import logging
+import json
+
+logging.basicConfig(level='INFO')
+
+
+def merge(args):
+    with open(args.targets_json) as f:
+        data = json.load(f)
+
+    targets = data['targets']
+
+    cur = targets[args.target_name]
+    cur_ver = int(cur['custom']['version'])
+    logging.info('Target is: %r', cur)
+
+    # Now find the previous version
+    prev = None
+    prev_ver = 0
+    for tgt in targets.values():
+        if tgt['custom'].get('name') == cur['custom']['name']:
+            tgt_ver = int(tgt['custom']['version'])
+            if tgt_ver > prev_ver and tgt_ver < cur_ver:
+                prev = tgt
+                prev_ver = tgt_ver
+
+    logging.info('Prev is: %r', prev)
+    if prev:
+        apps = prev['custom'].get('docker_apps')
+        if apps:
+            logging.info('Updating build to have apps: %r', apps)
+            cur['custom']['docker_apps'] = apps
+
+            with open(args.targets_json, 'w') as f:
+                json.dump(data, f, indent=2)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        'Copy the docker apps defined in previous target into the latest one.')
+
+    parser.add_argument('targets_json')
+    parser.add_argument('target_name')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = get_args()
+    merge(args)


### PR DESCRIPTION
This allows us to grab the latest docker apps by finding the previous
build and then including them in this build.

Signed-off-by: Andy Doan <andy@foundries.io>