### PR TITLE
lmp: Use AKLITE_TAG for premerge builds

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -106,6 +106,7 @@ triggers:
     type: github_pr
     params:
       OTA_LITE_TAG: premerge
+      AKLITE_TAG: premerge
     runs:
       - name: build-{loop}
         container: hub.foundries.io/lmp-sdk


### PR DESCRIPTION
AKLITE_TAG defaults to "promoted" and is used for generating the
sota.toml used in our release images. This keeps our premerge builds
from using that tag.

Signed-off-by: Andy Doan <andy@foundries.io>