### PR TITLE
factory-containers: Fix issue with "add-build"

### DIFF
--- a/factory-containers/ota-dockerapp.py
+++ b/factory-containers/ota-dockerapp.py
@@ -111,6 +111,8 @@ def add_build(args):
         data = json.load(f)
         for name, target in data['targets'].items():
             if target['custom']['targetFormat'] == 'OSTREE':
+                if target['custom'].get('tags') == ['premerge']:
+                    continue
                 hwid = target['custom']['hardwareIds'][0]
                 cur = latest.get(hwid)
                 ver = int(target['custom']['version'])


### PR DESCRIPTION
The issue can be seen  with CI build 659:

 https://ci.foundries.io/projects/lmp/builds/659/

The customize-target script picked the docker-apps from build 649 to
copy into the new 659 target. We were expecting the containers from
the latest container build 656. The problem is that build 656 looked
at the previous LMP build which was a "premerge". This caused the
`custome-targets` script to fail because the OSTREE_BRANCHNAME names
differ between pre and post merge builds.

Signed-off-by: Andy Doan <andy@foundries.io>