### PR TITLE
factory-containers: Add expanded tagging support

### DIFF
--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -123,6 +123,13 @@ for x in $IMAGES ; do
 	if [ $auth -eq 1 ] ; then
 		run docker push ${ct_base}:$TAG-$ARCH
 
+		var="EXTRA_TAGS_$ARCH"
+		for t in $(eval echo "\$$var") ; do
+			status "Tagging and pushing extra tag defined in docker-build.conf: $t"
+			run docker tag ${ct_base}:$TAG-$ARCH ${ct_base}:$t
+			run docker push ${ct_base}:$t
+		done
+
 		run manifest-tool push from-args \
 			--platforms $MANIFEST_PLATFORMS \
 			--template ${ct_base}:$TAG-ARCH \


### PR DESCRIPTION
This introduces a new docker-build.conf: EXTRA_TAGS_<ARCH>. This can
be used as follows:

 # docker-build.conf for a 32 bit container for arm and arm64
 # Don't build for aarch64:
 SKIP_ARCHS="arm64"
 EXTRA_TAGS_ARM="arm64"

This example would skip building a container for arm64. However, it
would tag the 32-bit image with -arm64 so it could run there as well.

Signed-off-by: Andy Doan <andy@foundries.io>