### PR TITLE
lmp/jobserv.yml: add job for build release stable

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -88,6 +88,75 @@ triggers:
         persistent-volumes:
           bitbake: /var/cache/bitbake
 
+  - name: build-release-stable
+    type: git_poller
+    email:
+      users: 'ci-notifications@foundries.io'
+    params:
+      GIT_URL: |
+        https://github.com/foundriesio/lmp-manifest.git
+      GIT_POLL_REFS: |
+        refs/heads/zeus
+      OTA_LITE_TAG: postmerge-stable
+      AKLITE_TAG: promoted-stable
+    runs:
+      # supported images
+      - name: supported-{loop}
+        container: hub.foundries.io/lmp-sdk
+        host-tag: amd64-osf
+        loop-on:
+          - param: MACHINE
+            values:
+              - raspberrypi3-64
+        params:
+          IMAGE: lmp-gateway-image
+          OSTREE_BRANCHNAME: lmp
+        script-repo:
+          name: fio
+          path: lmp/build.sh
+        persistent-volumes:
+          bitbake: /var/cache/bitbake
+
+      # other images
+      - name: other-{loop}
+        container: hub.foundries.io/lmp-sdk
+        host-tag: amd64-osf
+        loop-on:
+          - param: MACHINE
+            values:
+              - apalis-imx6
+              - beaglebone-yocto
+              - intel-corei7-64
+              - qemuarm64
+              - raspberrypi3
+              - raspberrypi4
+              - raspberrypi4-64
+        params:
+          IMAGE: lmp-gateway-image
+          OSTREE_BRANCHNAME: lmp
+        script-repo:
+          name: fio
+          path: lmp/build.sh
+        persistent-volumes:
+          bitbake: /var/cache/bitbake
+
+      # other mini images
+      - name: other-{loop}
+        container: hub.foundries.io/lmp-sdk
+        host-tag: amd64-osf
+        loop-on:
+          - param: MACHINE
+            values:
+              - qemuriscv64
+        params:
+          IMAGE: lmp-mini-image
+          OSTREE_BRANCHNAME: lmp
+        script-repo:
+          name: fio
+          path: lmp/build.sh
+        persistent-volumes:
+          bitbake: /var/cache/bitbake
+
   - name: Code Review
     type: github_pr
     params:


### PR DESCRIPTION
Similar to build-release, but following the lmp-manifest stable branch
(currently zeus). AKLITE_TAG and OTA_LITE_TAG also extended with -stable.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>