### PR TITLE
lmp/jobserv: stable: use containers from postmerge

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -97,7 +97,7 @@ triggers:
         https://github.com/foundriesio/lmp-manifest.git
       GIT_POLL_REFS: |
         refs/heads/zeus
-      OTA_LITE_TAG: postmerge-stable
+      OTA_LITE_TAG: 'postmerge-stable:postmerge'
       AKLITE_TAG: promoted-stable
     runs:
       # supported images


### PR DESCRIPTION
Change the current stable job to reuse the containers
available in postmerge, as we currently don't have a need
to split the containers into latest and stable.

This takes advantage of the new advanced tagging support
feature.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>