### PR TITLE
Allow containers to use secrets defined in JobServ

### DIFF
--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -18,6 +18,9 @@ require_params FACTORY
 
 run apk --no-cache add file git
 
+MANIFEST_PLATFORMS_DEFAULT="${MANIFEST_PLATFORMS_DEFAULT-linux/amd64,linux/arm,linux/arm64}"
+status Default container platforms will be: $MANIFEST_PLATFORMS_DEFAULT
+
 ARCH=amd64
 file /bin/busybox | grep -q aarch64 && ARCH=arm64 || true
 file /bin/busybox | grep -q armhf && ARCH=arm || true
@@ -92,7 +95,7 @@ for x in $IMAGES ; do
 	[ $found -eq 1 ] && continue
 
 	# allow the docker-build.conf to override our manifest platforms
-	MANIFEST_PLATFORMS="${MANIFEST_PLATFORMS-linux/amd64,linux/arm,linux/arm64}"
+	MANIFEST_PLATFORMS="${MANIFEST_PLATFORMS-${MANIFEST_PLATFORMS_DEFAULT}}"
 
 	ct_base="hub.foundries.io/${FACTORY}/$x"
 

--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -121,6 +121,14 @@ for x in $IMAGES ; do
 			docker_cmd="$docker_cmd  --no-cache"
 		fi
 
+		if [ -n "$DOCKER_SECRETS" ] ; then
+			status "DOCKER_SECRETS defined - building --secrets for $(ls /secrets)"
+			export DOCKER_BUILDKIT=1
+			for secret in `ls /secrets` ; do
+				docker_cmd="$docker_cmd --secret id=${secret},src=/secrets/${secret}"
+			done
+		fi
+
 		DOCKERFILE="$REPO_ROOT/$x/${DOCKERFILE-Dockerfile}"
 		if [ -n "$BUILD_CONTEXT" ] ; then
 			status "Using custom build context $BUILD_CONTEXT"


### PR DESCRIPTION
JobServ puts all project defined secrets as files under /secrets. This change allows a user to *securely* pass these secrets into a docker build context so that they may be used to do things like grab binaries from a secure registry.