### PR TITLE
containers: Handle buildkit bug for armhf

### DIFF
--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -24,6 +24,11 @@ export  DOCKER_CLI_EXPERIMENTAL=enabled
 MANIFEST_PLATFORMS_DEFAULT="${MANIFEST_PLATFORMS_DEFAULT-linux/amd64,linux/arm,linux/arm64}"
 status Default container platforms will be: $MANIFEST_PLATFORMS_DEFAULT
 
+if git log -1 | grep -q "\[ci nocache\]" ; then
+	status "[ci nocache] found in HEAD commit, forcing non-cached build"
+	NOCACHE="1"
+fi
+
 ARCH=amd64
 file /bin/busybox | grep -q aarch64 && ARCH=arm64 || true
 file /bin/busybox | grep -q armhf && ARCH=arm || true


### PR DESCRIPTION
We have 64bit ARMv8 hosts that run a 32bit LXC host that we run
docker inside of so that we can have fast armhf builds. There's some
bug in BuildKit that's not understanding this and tries to pull down
the wrong base image for the dockerfile and also can't pull the
"docker/dockerfile:1.0.0-expermential" image required. This is a small
hack that ensures we pull down the dockerfile and then build with
"--platform=$ARCH" so that BuildKit isn't confused. It helps fix errors
like:
```
 #6 [1/1] FROM docker.io/library/alpine:latest
 #6 resolve docker.io/library/alpine:latest 0.1s done
 #6 ERROR: no match for platform in manifest sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d: not found
 ------
  > [internal] load metadata for docker.io/library/alpine:latest:
 ------
 ------
  > [1/1] FROM docker.io/library/alpine:latest:
 ------
 failed to solve with frontend dockerfile.v0: failed to solve with frontend gateway.v0: rpc error: code = Unknown desc = failed to build LLB: failed to load cache key: no match for platform in manifest sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d: not found
```
Signed-off-by: Andy Doan <andy@foundries.io>