### PR TITLE
buildkit: use BUILDKIT_INLINE_CACHE=1

### DIFF
--- a/factory-containers/build.sh
+++ b/factory-containers/build.sh
@@ -124,6 +124,7 @@ for x in $IMAGES ; do
 		if [ -n "$DOCKER_SECRETS" ] ; then
 			status "DOCKER_SECRETS defined - building --secrets for $(ls /secrets)"
 			export DOCKER_BUILDKIT=1
+			docker_cmd="$docker_cmd --build-arg BUILDKIT_INLINE_CACHE=1"
 			for secret in `ls /secrets` ; do
 				docker_cmd="$docker_cmd --secret id=${secret},src=/secrets/${secret}"
 			done


### PR DESCRIPTION
Buildkit produces "inline" images which include the build cache and runtime imaged bundled as one. To properly use this cache during a buildkit build, we need to pass the flag BUILDKIT_INLINE_CACHE=1.

https://github.com/moby/moby/issues/39003

Signed-off-by: Tyler Baker <tyler@foundries.io>