### PR TITLE
Include source shas in TUF Target

### DIFF
--- a/factory-containers/ota-dockerapp.py
+++ b/factory-containers/ota-dockerapp.py
@@ -198,6 +198,7 @@ def create_target(args):
                 target['custom']['tags'] = [tag]
             apps = {}
             target['custom']['docker_apps'] = apps
+            target['custom']['containers-sha'] = os.environ['GIT_SHA']
             for app in args.apps:
                 filename = os.path.basename(app) + '-' + args.version
                 name = os.path.splitext(filename)[0]

--- a/lmp/customize-target
+++ b/lmp/customize-target
@@ -7,6 +7,7 @@ import argparse
 import logging
 import json
 import os
+import subprocess
 
 from copy import deepcopy
 
@@ -34,6 +35,12 @@ class TagMgr:
         return self._tags
 
 
+def git_hash(gitdir):
+    return subprocess.check_output(
+        ['git', 'log', '-1', '--format=%H'], cwd=gitdir
+    ).strip().decode()
+
+
 def merge(args):
     with open(args.targets_json) as f:
         data = json.load(f)
@@ -48,6 +55,12 @@ def merge(args):
     updates = []
     for idx, (tgt_tag, apps_tag) in enumerate(tagmgr.tags):
         tgt = targets[args.target_name]
+        tgt['custom']['lmp-manifest-sha'] = git_hash('/srv/oe/.repo/manifests')
+        try:
+            tgt['custom']['meta-subscriber-overrides-sha'] = git_hash(
+                '/srv/oe/layers/meta-subscriber-overrides')
+        except Exception:
+            pass  # okay - LMP build doesn't have this repo
         if idx:
             tgt = deepcopy(tgt)
             targets[args.target_name + '-%d' % idx] = tgt
@@ -82,6 +95,9 @@ def merge(args):
             if apps:
                 logging.info('Updating build to have apps: %r', apps)
                 u['tgt']['custom']['docker_apps'] = apps
+                sha = u['prev']['custom'].get('containers-sha')
+                if sha:
+                    u['tgt']['custom']['containers-sha'] = sha
                 changed = True
 
     if changed:


### PR DESCRIPTION
This change helps track the code source SHA's that produce a given
target. This will be useful for tools like fioctl, the webui, and the
lmp platform itself.

Signed-off-by: Andy Doan <andy@foundries.io>