### PR TITLE
lmp: build: fix stripping -b <ref> when hyphen is present

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -13,7 +13,7 @@ if [[ $GIT_URL == *"/lmp-manifest.git"* ]]; then
 	git branch pr-branch $GIT_SHA
 	# Check to make sure REPO_INIT_OVERRIDES isn't setting a "-b <ref>".
 	# That will break our logic for checking out the exact GIT_SHA above
-	export REPO_INIT_OVERRIDES=$(echo $REPO_INIT_OVERRIDES | sed -e 's/-b\s*\w*//')
+	export REPO_INIT_OVERRIDES=$(echo $REPO_INIT_OVERRIDES | sed -e 's/-b\s*\S*//')
 	mkdir /srv/oe && cd /srv/oe
 	repo_sync $manifest
 else


### PR DESCRIPTION
During processing of repo init command we strip potential "-b <ref>"
passed into REPO_INIT_OVERRIDES.  The current logic is:
remove "-b" + <any white space chars> + <any word chars>

If there's a hyphen in the <ref> it thinks this is a new word and
stops removal there.

So if REPO_INIT_OVERRIDES is:
-b home-assistant -m test.xml

We get:
-assistant -m test.xml

To fix this, let's change the removal logic to:
remove "-b" + <any whitespace chars> + <any non-whitespace chars>

This means stop the removal at the next occurance of a whitespace char.

Signed-off-by: Michael Scott <mike@foundries.io>