### PR TITLE
containers: Validate content of docker-compose file

### DIFF
--- a/factory-containers/publish-compose-apps
+++ b/factory-containers/publish-compose-apps
@@ -152,6 +152,8 @@ def main(factory: str, tag: str, platforms: str, sha: str, app_preload_flag: str
         if app.endswith('.disabled'):
             continue
         if os.path.exists(os.path.join(app, 'docker-compose.yml')):
+            status('Validating compose file for: ' + app)
+            cmd('docker-compose', 'config', cwd=app)
             status('Publishing compose app for: ' + app)
             uri = publish(factory, tag, app)
             apps[app] = {'uri': uri}


### PR DESCRIPTION
We don't always catch compose syntax errors and when we do, the error
messages aren't always obvious. This should help by using the actual
compose tooling.

Signed-off-by: Andy Doan <andy@foundries.io>