### PR TITLE
lmp: Support dynamically scoped token in creds.zip

### DIFF
--- a/create-creds
+++ b/create-creds
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+import sys
+
+from helpers import generate_credential_tokens, require_secrets
+
+
+def main(creds_in, creds_out):
+    require_secrets('osftok', 'triggered-by')
+    generate_credential_tokens(creds_in, creds_out)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        sys.exit('Usage: %s <creds.zip-in> <creds.zip-out>' % sys.argv[0])
+    main(sys.argv[1], sys.argv[2])

--- a/factory-containers/docker-app-publish.sh
+++ b/factory-containers/docker-app-publish.sh
@@ -34,7 +34,8 @@ if [ -n "$DOCKER_COMPOSE_APP" ] ; then
 	chmod +x /usr/local/bin/compose-ref
 fi
 
-CREDENTIALS=/var/cache/bitbake/credentials.zip
+CREDENTIALS=$(mktemp)
+$HERE/../create-creds /var/cache/bitbake/credentials.zip $CREDENTIALS
 export TAG=$(git log -1 --format=%h)
 
 tufrepo=$(mktemp -u -d)

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -21,6 +21,13 @@ if [ "$ENABLE_PTEST" = "1" ] ; then
     OSTREE_BRANCHNAME="${OSTREE_BRANCHNAME}-ptest"
 fi
 
+if [ -n "$SOTA_PACKED_CREDENTIALS" ] && [ -f $SOTA_PACKED_CREDENTIALS ] ; then
+	status "Generating credentials.zip"
+	dynamic=$(mktemp --suffix=.zip)
+	$HERE/../create-creds $SOTA_PACKED_CREDENTIALS $dynamic
+	SOTA_PACKED_CREDENTIALS=$dynamic
+fi
+
 source setup-environment build
 
 cat << EOFEOF >> conf/local.conf


### PR DESCRIPTION
This change allows us to set the client_secret value of credentials.zip
during each build. This will allow us to remove this client_secret
value making the credentials.zip file a little more secure.

Signed-off-by: Andy Doan <andy@foundries.io>