### PR TITLE
assemble: make sure installed target base dir exists

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -65,6 +65,8 @@ class WicImage:
 
     def update_target(self, target_json):
         logger.info('Updating installed Target (aka `installed_versions`) for the given system image\n')
+        # make sure installed target dir path exists (e.g. wic-based installers)
+        os.makedirs(os.path.dirname(self.installed_target_filepath), exist_ok=True)
         with open(self.installed_target_filepath, 'w') as installed_target_file:
             target_json['is_current'] = True
             json.dump(target_json, installed_target_file, indent=2)


### PR DESCRIPTION
On wic-based image installers we don't have the entire installed target
base dir path created (only the root ext4 image), so make sure to create
the required dirname when writing the updated installed_versions file.

This won't cause any difference on the traditional wic images and will
make the required path/file to be available for the wic efi installer
(which will then copy over to the right location while performing the
install process).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>