### PR TITLE
containers: Pull in host config when present

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -24,6 +24,11 @@ export  DOCKER_CLI_EXPERIMENTAL=enabled
 MANIFEST_PLATFORMS_DEFAULT="${MANIFEST_PLATFORMS_DEFAULT-linux/amd64,linux/arm,linux/arm64}"
 status Default container platforms will be: $MANIFEST_PLATFORMS_DEFAULT
 
+if [ -f /secrets/docker_host_config.json ] ; then
+	mkdir -p $HOME/.docker
+	cp /secrets/docker_host_config.json $HOME/.docker/config.json
+fi
+
 ARCH=amd64
 file /bin/busybox | grep -q aarch64 && ARCH=arm64 || true
 file /bin/busybox | grep -q armhf && ARCH=arm || true


### PR DESCRIPTION
Due to docker rate-limiting we now need an authenticated read-only
docker hub account to help keep us from hit docker rate limits.

We added this into jobserv:

 https://github.com/foundriesio/jobserv/commit/eb8a3cba17194541a58939cbbee48ee91f7359d5

Signed-off-by: Andy Doan <andy@foundries.io>