### PR TITLE
lmp/bb-config: always disable sstate mirrors

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -143,12 +143,10 @@ INHERIT += "archiver"
 COPYLEFT_RECIPE_TYPES = "target"
 ARCHIVER_MODE[src] = "original"
 ARCHIVER_MODE[diff] = "1"
-EOFEOF
 
-if [ $(ls ../sstate-cache | wc -l) -ne 0 ] ; then
-	status "Found existing sstate cache, using local copy"
-	echo 'SSTATE_MIRRORS = ""' >> conf/auto.conf
-fi
+# no sstate mirrors, using local copy
+SSTATE_MIRRORS = ""
+EOFEOF
 
 for x in $(ls conf/*.conf) ; do
 	status "$x"


### PR DESCRIPTION
Minor one, but noticed when comparing master x devel (only devel had SSTATE_MIRROR disabled).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>