### PR TITLE
lmp/bb-config: drop exports from local.conf

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -122,11 +122,6 @@ fi
 
 # Add build id H_BUILD to output files names
 cat << EOFEOF >> conf/auto.conf
-IMAGE_NAME_append = "-${H_BUILD}"
-KERNEL_IMAGE_BASE_NAME_append = "-${H_BUILD}"
-MODULE_IMAGE_BASE_NAME_append = "-${H_BUILD}"
-DT_IMAGE_BASE_NAME_append = "-${H_BUILD}"
-BOOT_IMAGE_BASE_NAME_append = "-${H_BUILD}"
 DISTRO_VERSION_append = "-${H_BUILD}-${LMP_VERSION}"
 
 # get build stats to make sure that we use sstate properly

--- a/tests/test_lmp_tagging.py
+++ b/tests/test_lmp_tagging.py
@@ -63,11 +63,10 @@ def temp_json_file(data):
 
 
 def customize_target(tag, targets_file, target_name):
-    args = ['./lmp/customize-target.sh', 'machine_name', 'lmp-factory-image', 'amd64',
-            targets_file, target_name, '--manifest-repo=./', '--meta-sub-overrides-repo=./']
-    env = os.environ.copy()
-    env['OTA_LITE_TAG'] = tag
-    subprocess.check_call(args, env=env)
+    args = ['./lmp/customize-target.sh', 'lmp', tag, 'machine_name',
+            'lmp-factory-image', 'amd64', targets_file, target_name,
+            '--manifest-repo=./', '--meta-sub-overrides-repo=./']
+    subprocess.check_call(args)
     with open(targets_file) as f:
         return json.load(f)
 


### PR DESCRIPTION
Drop the need for exporting variables from local.conf as that causes a
massive bad side effect on caching.

Move variables to be provided as parameters for the customize-target
script instead, and drop variables that are not used by LMP.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>