### PR TITLE
lmp: add custom debug config log and publish debug/warning

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -6,6 +6,6 @@ require_params IMAGE
 
 source setup-environment build
 
-bitbake ${IMAGE}
-
 bitbake -e | grep "^DEPLOY_DIR="| cut -d'=' -f2 | tr -d '"' > deploy_dir
+
+bitbake -D ${IMAGE}

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -71,6 +71,9 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 
 # mfgtool params
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
+
+# Bitbake custom logconfig
+BB_LOGCONFIG = "${HERE}/bb_logconfig.json"
 EOFEOF
 
 # Ptest-based builds require the same build settings and variables,

--- a/lmp/bb_logconfig.json
+++ b/lmp/bb_logconfig.json
@@ -1,0 +1,49 @@
+{
+    "version": 1,
+    "handlers": {
+        "BitBake.console": {
+            "class": "logging.StreamHandler",
+            "formatter": "debugFormatter",
+            "level": "INFO",
+            "stream": "ext://sys.stdout",
+            "filters": ["BitBake.stdoutFilter"],
+            ".": {
+                "is_console": true
+            }
+        },
+        "bitbake_debug": {
+            "class": "logging.FileHandler",
+            "formatter": "debugFormatter",
+            "filename": "bitbake_debug.log",
+            "level": "DEBUG",
+            "mode": "w"
+        },
+        "bitbake_warnings": {
+            "class": "logging.FileHandler",
+            "formatter": "jsonFormatter",
+            "filename": "bitbake_warning.log",
+            "level": "WARNING",
+            "mode": "w"
+        }
+    },
+    "formatters": {
+        "debugFormatter": {
+            "format": "(%(asctime)s) %(levelname)s: %(message)s"
+        },
+        "jsonFormatter": {
+            "class": "jsonformatter.JsonFormatter",
+            "format": {
+                "levelname": "levelname",
+                "message": "message"
+            }
+        }
+    },
+    "loggers": {
+        "BitBake": {
+            "handlers": [
+                "bitbake_debug",
+                "bitbake_warnings"
+            ]
+        }
+    }
+}

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -95,6 +95,13 @@ fi
 if [ -d "${archive}" ] ; then
 	mkdir ${archive}/other
 
+	# Compress and publish bitbake's debug build output
+	if [ -f build/bitbake_debug.log ]; then
+		gzip -f build/bitbake_debug.log
+		mv build/bitbake_debug.log.gz ${archive}/other/
+		mv build/bitbake_warning.log ${archive}/other/
+	fi
+
 	# Compress and publish source tarball (for *GPL* packages)
 	if [ -d ${DEPLOY_DIR_IMAGE}/source-release ]; then
 		tar --remove-files -C ${DEPLOY_DIR_IMAGE} -cf ${MACHINE}-source-release.tar source-release


### PR DESCRIPTION
Add logic for handling a custom config log that improves the standard stdout output by adding timestamp and redirects the warn/debug information into 2 files, which are later uploaded as part of the build process.

You can see how it looks like by checking https://ci.foundries.io/projects/rsalveti-v77/lmp/builds/9/n1sdp/artifacts/console.log.