### PR TITLE
apps: Handle publishing for docker-compose.yaml files

### DIFF
--- a/apps/compose_apps.py
+++ b/apps/compose_apps.py
@@ -21,7 +21,11 @@ class ComposeApps:
 
         @staticmethod
         def is_compose_app_dir(app_dir):
-            return os.path.exists(os.path.join(app_dir, ComposeApps.App.ComposeFile))
+            typo_file = os.path.join(app_dir, 'docker-compose.yaml')
+            exists = os.path.exists(os.path.join(app_dir, ComposeApps.App.ComposeFile))
+            if not exists and os.path.exists(typo_file):
+                raise ValueError('docker-compose.yaml file found. This must be named docker-compose.yml')
+            return exists
 
         def __init__(self, name, app_dir, validate=False, image_downloader_cls=DockerDownloader):
             if not self.is_compose_app_dir(app_dir):


### PR DESCRIPTION
We currently only look for `docker-compose.yml` files. This can be
confusing to a user that creates a `docker-compose.yaml`.

This isn't the cleanest approach, but our code expects
docker-compose.yml in a couple of places. This fixes things in the
least invasive way.

Signed-off-by: Andy Doan <andy@foundries.io>