### PR TITLE
lmp/jobserv: trigger test merge after successful build

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -4,6 +4,10 @@ triggers:
     type: git_poller
     email:
       users: 'ci-notifications@foundries.io'
+    webhooks:
+      - url: https://conductor.infra.foundries.io/api/lmp/
+        failures_only: false
+        secret_name: lava
     params:
       GIT_URL: |
         https://github.com/foundriesio/lmp-manifest.git


### PR DESCRIPTION
The trigger sends POST request to Conductor which runs the testing rig.
The test merge happens in all "testing" factories. Successful manifest
merge will trigger automated testing round.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>