### PR TITLE
lmp: delta: no 'objects' folder is required

### DIFF
--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -90,7 +90,6 @@ def main(creds_zip_file: str, deltas: List[Delta]):
             prog.tick()
 
     rmtree("./ostree_repo/objects")  # We just need to sync deltas
-    os.mkdir("./ostree_repo/objects")   # make fiopush happy
     cmd("fiopush", "-summary", "-repo=./ostree_repo", "-creds", creds_zip_file)
     prog.tick()
 


### PR DESCRIPTION
Don't create 'objects' folder, it became not mandatory since
https://github.com/foundriesio/ostreehub/commit/b5a9e11750e29dcd225aa9f7ba76c6cd0a1bc64b

Signed-off-by: Mike Sul <mike.sul@foundries.io>