### PR TITLE
apps/build: use buildx caching

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -104,13 +104,16 @@ for x in $IMAGES ; do
 	# If NOCACHE is not set, only build images that have changed.
 	if [ -z "$NOCACHE" ] ; then
 		no_op_tag=0
-		# If we cannot obtain the diff, force the build
-		CHANGED=$(git diff --name-only $GIT_OLD_SHA..$GIT_SHA $x/${BUILD_CONTEXT} || echo FORCE_BUILD)
-		if [[ ! -z "$CHANGED" ]]; then
-			status "Detected changes to $x"
-		else
-			status "No changes to $x, tagging only"
-			no_op_tag=1
+		# If we are using buildx, don't try to guess what has changed
+		if [ -z "$DOCKER_SECRETS" ] ; then
+			# If we cannot obtain the diff, force the build
+			CHANGED=$(git diff --name-only $GIT_OLD_SHA..$GIT_SHA $x/${BUILD_CONTEXT} || echo FORCE_BUILD)
+			if [[ ! -z "$CHANGED" ]]; then
+				status "Detected changes to $x"
+			else
+				status "No changes to $x, tagging only"
+				no_op_tag=1
+			fi
 		fi
 	fi
 
@@ -137,7 +140,7 @@ for x in $IMAGES ; do
 		docker login hub.foundries.io --username=doesntmatter --password=$(cat /secrets/osftok) | indent
 		# sanity check and pull in a cached image if it exists. if it can't be pulled set no_op_tag to 0.
 		run docker pull ${ct_base}:${LATEST} || no_op_tag=0
-		if [ $no_op_tag -eq 0 ] && [ -z "$CHANGED" ]; then
+		if [ $no_op_tag -eq 0 ] && [ -z "$CHANGED" ] && [ -z "$DOCKER_SECRETS" ] ; then
 			status "WARNING - no cached image found, forcing a rebuild"
 		fi
 		auth=1


### PR DESCRIPTION
Now that we have enabled buildx, we publish the build cache each CI run.
We can remove the complex logic to figure out which app changed, and just
use the build cache we are already pulling in.

Signed-off-by: Tyler Baker <tyler@foundries.io>