### PR TITLE
Add ability to bundle encrypted apps into the system image

### DIFF
--- a/apps/target_apps_store.py
+++ b/apps/target_apps_store.py
@@ -98,7 +98,7 @@ class ArchiveTargetAppsStore(TargetAppsStore):
 
         return app_image_size
 
-    def _copy_encrypted(self, app_img: str, dst_images_dir: str, encrypt_apps: str):
+    def _copy_encrypted(self, app_img: str, dst_images_dir: str, encryption_key: str):
         path = os.path.join(dst_images_dir, 'extract-encrypted-apps')
         logger.info('Creating self extracting encrypted file: %s', path)
         with open(path, 'wb') as f:
@@ -106,7 +106,7 @@ class ArchiveTargetAppsStore(TargetAppsStore):
             f.write(EXTRACTION_SCRIPT.encode())
             f.flush()
             subprocess.check_call(['openssl', 'enc', '-pbkdf2', '-e', '-aes256',
-                                   '-in', app_img, '-k', encrypt_apps], stdout=f)
+                                   '-in', app_img, '-k', encryption_key], stdout=f)
 
     def copy(self, target: FactoryClient.Target, dst_images_dir: str, dst_apps_dir: str):
         if not self.exist(target):

--- a/assemble-system-image.sh
+++ b/assemble-system-image.sh
@@ -19,6 +19,7 @@ TARGET_VERSION="${TARGET_VERSION-${H_BUILD}}"
 OUT_IMAGE_DIR="${OUT_IMAGE_DIR-/archive}"
 APPS_OSTREE_REPO_ARCHIVE_DIR="${APPS_OSTREE_REPO_ARCHIVE_DIR-/var/cache/bitbake/app-images/}"
 APP_SHORTLIST="${APP_SHORTLIST-""}"
+APP_ENCRYPTED="${APP_ENCRYPTED-""}"
 COMPOSE_APP_USE_OSTREE=${COMPOSE_APP_USE_OSTREE-""}
 OSTREE_REPO_DIR="${OSTREE_REPO_DIR-$(mktemp -d)}"
 # directory to preload/dump/snapshot apps images to
@@ -43,4 +44,5 @@ status Running: Assemble System Image script
   --fetch-dir "${FETCH_DIR}" \
   --targets "${TARGETS}" \
   --app-shortlist="${APP_SHORTLIST}" \
+  --app-encrypted="${APP_ENCRYPTED}" \
   --use-ostree="${COMPOSE_APP_USE_OSTREE}"

--- a/assemble.py
+++ b/assemble.py
@@ -140,8 +140,7 @@ def copy_container_images_from_archive_to_wic(target: FactoryClient.Target, app_
     if not target_app_store.exist(target):
         logger.info('Container images have not been found, trying to obtain them...')
         apps_fetcher = TargetAppsFetcher(token, app_preload_dir)
-        apps_fetcher.fetch_target_apps(target, target.shortlist)
-        apps_fetcher.fetch_apps_images()
+        apps_fetcher.fetch_target(target)
         target_app_store.store(target, apps_fetcher.target_dir(target.name))
     p.tick()
 

--- a/factory_client.py
+++ b/factory_client.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 import logging
 import subprocess
@@ -18,6 +19,10 @@ class FactoryClient:
             self.json = target_json
             self.shortlist = shortlist
             self._set_apps_commit_hash()
+            self.app_encrypted_key = None
+
+        def copy(self, new_name: str, shortlist=None):
+            return FactoryClient.Target(new_name, deepcopy(self.json), shortlist)
 
         @property
         def platform(self):


### PR DESCRIPTION
This is a 3 part change:

* Passing short-list as a parameter to target-store makes no sense. The target store names the artifact using the the Target.shortlist attribute.
* Target fetching could be simplified and made more consistent
* Support of encrypted apps.

In the end you can run a command like `fioctl secrets update app-encrypted-key=SuperSecretValue` and then have a factory config ref option like
~~~
refs/heads/devel:
      params:
        APP_SHORTLIST: "shellhttpd"
        APP_ENCRYPTED: "fiotest"
~~~

This will produce a system image with shellhttpd preloaded and included in the initial Target aklite runs. There will also be a self extracting file `/var/sota/extract-encrypted-apps SuperSecretValue`. At this point the containers and compose app will be in place. 