### PR TITLE
apps: build: drop image label to fix manifest sha

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -154,7 +154,7 @@ for x in $IMAGES ; do
 		status Tagging docker image $x for $ARCH
 		run docker tag ${ct_base}:${LATEST} ${ct_base}:$TAG-$ARCH
 	else
-		docker_cmd="$docker_build --label \"jobserv_build=$H_BUILD\" -t ${ct_base}:$TAG-$ARCH --force-rm"
+		docker_cmd="$docker_build -t ${ct_base}:$TAG-$ARCH --force-rm"
 		if [ -z "$NOCACHE" ] ; then
 			status Building docker image $x for $ARCH with cache
 			docker_cmd="$docker_cmd  --cache-from ${ct_base}:${LATEST}"


### PR DESCRIPTION
Testing shows that using --label="..." with a different value
each time you run a build will generate a different manifest sha
when pushed to a registry.

This label is used to identify the build a particular image was
created in.  For now, let's drop the label and investigate a
better way to identify images on hub.foundries.io (if at all).

Signed-off-by: Michael Scott <mike@foundries.io>