### PR TITLE
containers: Include build number in container tag

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -221,9 +221,9 @@ for x in $IMAGES ; do
 		for arch in `echo $MANIFEST_PLATFORMS | sed -e 's/linux\///g' -e 's/,/ /g'` ; do
 			manifest_args="${manifest_args} ${ct_base}:$TAG-$arch"
 		done
-		run docker manifest create ${ct_base}:$TAG $manifest_args && \
+		run docker manifest create ${ct_base}:${H_BUILD}_$TAG $manifest_args && \
 			run docker manifest create ${ct_base}:$LATEST $manifest_args && \
-			run docker manifest push ${ct_base}:$TAG && \
+			run docker manifest push ${ct_base}:${H_BUILD}_$TAG && \
 			run docker manifest push ${ct_base}:$LATEST || true
 	else
 		echo "osftoken not provided, skipping publishing step"

--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -27,7 +27,7 @@ COMPOSE_APP_USE_OSTREE=${COMPOSE_APP_USE_OSTREE-""}
 APPS_ROOT_DIR=${APPS_ROOT_DIR-${PWD}}
 PUBLISH_TOOL=${PUBLISH_TOOL-""}
 
-APPS_VERSION=${APPS_VERSION-$(git --git-dir="${APPS_ROOT_DIR}/.git" log -1 --format=%h)}
+APPS_VERSION=${H_BUILD}_${APPS_VERSION-$(git --git-dir="${APPS_ROOT_DIR}/.git" log -1 --format=%h)}
 GIT_SHA=${GIT_SHA-$(git --git-dir="${APPS_ROOT_DIR}/.git" log -1 --format=%H)}
 TARGET_VERSION=${H_BUILD-""}
 


### PR DESCRIPTION
In commit ab7f7f05b77490dce039d9ae68d5b215c5ba15c3 we stopped including
the build number in the container metadata. hub.foundries.io is using
that data to understand what build number (Target version) produced the
container. This change adds the build number into the container image's
tag so that we can infer it.

Signed-off-by: Andy Doan <andy@foundries.io>