### PR TITLE
containers: Include more accurate TUF custom data

### DIFF
--- a/apps/target_manager.py
+++ b/apps/target_manager.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2020 Foundries.io
 # SPDX-License-Identifier: Apache-2.0
-
+import datetime
 import logging
+import os
 import json
 from copy import deepcopy
 
@@ -104,6 +105,16 @@ def create_target(targets_json, compose_apps, ota_lite_tag, git_sha, machines, p
             target = deepcopy(target)
             tgt_name = tagmgr.create_target_name(target, version, tag)
             data['targets'][tgt_name] = target
+
+            now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+            target['custom']['createdAt'] = now
+            target['custom']['updatedAt'] = now
+            uri = target['custom'].get('uri')
+            if uri:
+                target['custom']['origUri'] = uri
+            proj = os.environ['H_PROJECT']
+            build = os.environ['H_BUILD']
+            target['custom']['uri'] = f'https://ci.foundries.io/projects/{proj}/builds/{build}'
 
             target['custom']['version'] = version
             if tag:

--- a/tests/test_container_tagging.py
+++ b/tests/test_container_tagging.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import unittest
 
 from contextlib import contextmanager
@@ -104,6 +105,9 @@ def create_target(tag, version, targets_file, apps, machines=None, platforms=Non
 
 
 class TestTagging(unittest.TestCase):
+    def setUp(self):
+        os.environ['H_PROJECT'] = 'ci-test'
+        os.environ['H_BUILD'] = '42'
 
     def test_one_to_one(self):
         """Make sure the most basic one-to-one tagging method works."""


### PR DESCRIPTION
Inheriting from the LmP build is a little confusing to users as they'll
see a createdAt timestamp in the past and a URI that doesn't point to
the CI job that created this Target.

Signed-off-by: Andy Doan <andy@foundries.io>