### PR TITLE
containers: Pin version of buildkit

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -74,7 +74,7 @@ for i in `seq 12` ; do
 done
 
 if [ -n "$DOCKER_BUILDX" ] ; then
-	run docker buildx create --use
+	run docker buildx create --driver-opt image=moby/buildkit:v0.8.3 --use
 fi
 
 TAG=$(git log -1 --format=%h)


### PR DESCRIPTION
Docker can change this and it can break us. We are currently seeing
the latest "stable" breaks armhf. This pins us to the stable tested
version we've been using. We can then upgrade when we choose.

Signed-off-by: Andy Doan <andy@foundries.io>