### PR TITLE
assemble wic: drop hard-coded partition used for resizing

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -30,7 +30,7 @@ class WicImage:
 
     def __init__(self, wic_image_path: str, increase_bytes=None, extra_space=0.2):
         self._path = wic_image_path
-        self._mnt_dir = os.path.join('/mnt', 'wic_image_p2')
+        self._mnt_dir = os.path.join('/mnt', 'wic_image_rootfs')
         self._resized_image = False
         if increase_bytes:
             self._resize_wic_file(increase_bytes, extra_space)

--- a/assemble.py
+++ b/assemble.py
@@ -89,8 +89,8 @@ class WicImage:
             'conv=notrunc', 'oflag=append', 'count=' + str(increase_k),
             'seek=' + str(wic_k))
 
-        fdsik_out = str(subprocess.check_output(['fdisk', '-l', self._path]))
-        if fdsik_out.find('using GPT') != -1:
+        parted_out = str(subprocess.check_output(['parted', self._path, 'print']))
+        if parted_out.find('Partition Table: gpt') != -1:
             subprocess.check_call(['sgdisk', '-e', self._path])
         subprocess.check_call(['parted', self._path, 'resizepart', '2', '100%'])
 


### PR DESCRIPTION
Currently the assemble wic script uses a hard-coded value of 2 for resizing the rootfs.

This is not always true.

Let's use the last line of the `fdisk` output as a guide for the last partition (which is the only one that can be resized anyway).