### PR TITLE
containers: Add logic for private container registries

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -16,7 +16,8 @@ HERE=$(dirname $(readlink -f $0))
 
 require_params FACTORY
 
-run apk --no-cache add file git
+# temp while we move to foundries/dind-ci image
+run apk --no-cache add file git || true
 
 # required for "docker manifest"
 export  DOCKER_CLI_EXPERIMENTAL=enabled

--- a/apps/login_registries
+++ b/apps/login_registries
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from helpers import status
+
+
+if len(sys.argv) != 2:
+    sys.exit("Usage: %s <registry data file>" % sys.argv[0])
+
+with open(sys.argv[1]) as f:
+    registries = json.load(f)
+
+for reg in registries:
+    status("Configuring registry %s - %s" % (reg["type"], reg["url"]))
+    if reg["type"] == "aws":
+        creds_file = Path.home() / ".aws/credentials"
+        creds_file.parent.mkdir()
+        secrets_file = Path("/secrets") / reg["aws_creds_secret_name"]
+        creds_file.write_text(secrets_file.read_text())
+
+        try:
+            cmd = ["aws", "ecr", "get-login-password", "--region", reg["region"]]
+            token = subprocess.check_output(cmd)
+            cmd = ["docker", "login", "--password-stdin", "-u", "AWS", reg["url"]]
+            subprocess.run(cmd, check=True, input=token)
+        except subprocess.CalledProcessError as e:
+            sys.exit(e.returncode)
+    else:
+        sys.exit("Unsupported registry type")

--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -54,6 +54,10 @@ if [ -f $pbc ] ; then
   . $pbc
 fi
 
+if [ -f /secrets/container-registries ] ; then
+	PYTHONPATH=$HERE/.. $HERE/login_registries /secrets/container-registries
+fi
+
 status Doing docker-login to hub.foundries.io with secret
 docker login hub.foundries.io --username=doesntmatter --password="$(cat "${SECRETS}/osftok")" | indent
 

--- a/assemble-system-image.sh
+++ b/assemble-system-image.sh
@@ -31,6 +31,10 @@ if [ -z "${TARGETS}" ] && [ -z "${TARGET_VERSION}" ]; then
   exit 1
 fi
 
+if [ -f /secrets/container-registries ] ; then
+	PYTHONPATH=$HERE $HERE/apps/login_registries /secrets/container-registries
+fi
+
 OPTIONS=""
 if [ "${COMPOSE_APP_TYPE}" = "restorable" ]; then
   OPTIONS="--restorable-apps"


### PR DESCRIPTION
Factories may be configured with private container registries. CI
will set these with a "secret" that we can execute to login with.

Signed-off-by: Andy Doan <andy@foundries.io>