### PR TITLE
containers: Hack for CI container upgrade

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -16,7 +16,8 @@ HERE=$(dirname $(readlink -f $0))
 
 require_params FACTORY
 
-run apk --no-cache add file git
+# temp while we move to foundries/dind-ci image
+run apk --no-cache add file git || true
 
 # required for "docker manifest"
 export  DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
armhf fails when you run `apk add` for a package already installed.

Signed-off-by: Andy Doan <andy@foundries.io>