### PR TITLE
Move to using totally dynamic creds.zip

### DIFF
--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -31,7 +31,6 @@ APPS_VERSION=${H_BUILD}_${APPS_VERSION-$(git --git-dir="${APPS_ROOT_DIR}/.git" l
 GIT_SHA=${GIT_SHA-$(git --git-dir="${APPS_ROOT_DIR}/.git" log -1 --format=%H)}
 TARGET_VERSION=${H_BUILD-""}
 
-CREDS_ARCH=${CREDS_ARCH-/var/cache/bitbake/credentials.zip}
 CREDS_ARCH_UPDATED=${CREDS_ARCH_UPDATED-$(mktemp -p ${HOME})}
 PUSH_TARGETS=${PUSH_TARGETS-true}
 
@@ -70,7 +69,7 @@ fi
 
 export PYTHONPATH=${HERE}/../
 
-"$HERE"/../create-creds "${CREDS_ARCH}" "${CREDS_ARCH_UPDATED}"
+"$HERE"/../create-creds "${CREDS_ARCH_UPDATED}"
 export TAG=$(git log -1 --format=%h)
 
 if [ ! -f "${TUF_REPO}/credentials.zip" ]; then

--- a/create-creds
+++ b/create-creds
@@ -4,12 +4,12 @@ import sys
 from helpers import generate_credential_tokens, require_secrets
 
 
-def main(creds_in, creds_out):
-    require_secrets('osftok', 'triggered-by')
-    generate_credential_tokens(creds_in, creds_out)
+def main(creds_out):
+    require_secrets('osftok', 'triggered-by', 'targets.sec')
+    generate_credential_tokens(creds_out)
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        sys.exit('Usage: %s <creds.zip-in> <creds.zip-out>' % sys.argv[0])
-    main(sys.argv[1], sys.argv[2])
+    if len(sys.argv) != 2:
+        sys.exit('Usage: %s <creds.zip-out>' % sys.argv[0])
+    main(sys.argv[1])

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -29,10 +29,10 @@ if [ "$ENABLE_PTEST" = "1" ] ; then
     OSTREE_BRANCHNAME="${OSTREE_BRANCHNAME}-ptest"
 fi
 
-if [ -n "$SOTA_PACKED_CREDENTIALS" ] && [ -f $SOTA_PACKED_CREDENTIALS ] ; then
+if [ -f "/secrets/targets.sec" ] ; then
 	status "Generating credentials.zip"
 	dynamic=$(mktemp --suffix=.zip)
-	$HERE/../create-creds $SOTA_PACKED_CREDENTIALS $dynamic
+	$HERE/../create-creds $dynamic
 	SOTA_PACKED_CREDENTIALS=$dynamic
 fi
 

--- a/lmp/create-creds
+++ b/lmp/create-creds
@@ -13,7 +13,7 @@ cat /secrets/credentials_zip_b64 \
 sha=$(sha256sum /var/cache/bitbake/credentials.zip | cut -f1 -d\  )
 
 CREDENTIALS=$(mktemp)
-$HERE/../create-creds /var/cache/bitbake/credentials.zip $CREDENTIALS
+$HERE/../create-creds $CREDENTIALS
 
 status "Extracting credentials"
 garage-sign init --repo ./tufrepo --credentials $CREDENTIALS

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -95,10 +95,9 @@ def main(creds_zip_file: str, deltas: List[Delta]):
 
 
 if __name__ == "__main__":
-    require_secrets("osftok", "triggered-by", "deltas")
-    creds, = require_env("SOTA_PACKED_CREDENTIALS")
+    require_secrets("osftok", "triggered-by", "deltas", "targets.sec")
     _, creds_tmp = mkstemp()
-    generate_credential_tokens(creds, creds_tmp)
+    generate_credential_tokens(creds_tmp)
 
     deltas: List[Delta] = []
     for d in json.loads(secret("deltas")):

--- a/lmp/update-targets
+++ b/lmp/update-targets
@@ -6,7 +6,7 @@ source $HERE/../helpers.sh
 apk add curl
 
 CREDENTIALS=$(mktemp)
-$HERE/../create-creds /var/cache/bitbake/credentials.zip $CREDENTIALS
+$HERE/../create-creds $CREDENTIALS
 
 status Extracting credentials
 garage-sign init --repo /tufrepo --credentials $CREDENTIALS


### PR DESCRIPTION
JobServ now sends us the target.sec file. This means there's no need
to rely on the contents of an NFS copy of credentials.zip.

Signed-off-by: Andy Doan <andy@foundries.io>