### PR TITLE
lmp: Add ssh-agent support for recipes

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -4,6 +4,21 @@ HERE=$(dirname $(readlink -f $0))
 source $HERE/../helpers.sh
 require_params IMAGE
 
+keys=$(ls /secrets/ssh-*.key 2>/dev/null || true)
+if [ -n "$keys" ] ; then
+	status Found ssh keys, starting an ssh-agent
+	eval `ssh-agent`
+	for x in $keys ; do
+		echo " Adding $x"
+		ssh-add $x
+	done
+	if [ -f /secrets/ssh-known_hosts ] ; then
+		status " Adding known hosts file"
+		mkdir -p $HOME/.ssh
+		ln -s /secrets/ssh-known_hosts $HOME/.ssh/known_hosts
+	fi
+fi
+
 source setup-environment build
 
 bitbake -D ${IMAGE}


### PR DESCRIPTION
Customer's may have bitbake recipes referencing private ssh+git
repositories. This change allows users to configure Factory support by
naming convention with fioctl-secrets. For example a user can create 2
secrets:

 ssh-github.key - content coming from ssh-keygen (i.e id_rsa)
 ssh-known_hosts - the fingerprint(s) of the server to be connected to

If these are detected, the bitbake build process will launch ssh-agent,
ssh-add the key(s), and set the known_hosts file so that git-clones
won't prompt for user input.

Signed-off-by: Andy Doan <andy@foundries.io>