### PR TITLE
apps: pass arch list to the publish tool

### DIFF
--- a/apps/apps_publisher.py
+++ b/apps/apps_publisher.py
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class AppsPublisher:
-    def __init__(self, factory, publish_tool: str, registry_host=DockerRegistryClient.DefaultRegistryHost):
+    def __init__(self, factory, publish_tool: str, archs: str, registry_host=DockerRegistryClient.DefaultRegistryHost):
         self._factory = factory
         self._publish_tool = publish_tool
+        self._archs = archs
         self._registry_host = registry_host
 
         self._image_base_url = '{}/{}'.format(registry_host, self._factory)
@@ -82,5 +83,5 @@ class AppsPublisher:
         self._app_tagged_url = app_base_url + ':app-' + tag
         # TODO: Consider implementation of the "publish tool" in DockerRegistryClient
         with NamedTemporaryFile(mode="w+") as f:
-            cmd_exe(self._publish_tool, '-d', f.name, self._app_tagged_url, cwd=app.dir)
+            cmd_exe(self._publish_tool, '-d', f.name, self._app_tagged_url, self._archs, cwd=app.dir)
             return app_base_url + '@' + f.read().strip()

--- a/apps/publish.py
+++ b/apps/publish.py
@@ -28,7 +28,7 @@ def main(factory: str, sha: str, targets_json: str, machines: [], platforms: [],
     apps.validate()
     status('Compose Apps has been validated: {}'.format(apps.str))
 
-    apps_to_add_to_target = AppsPublisher(factory, publish_tool).publish(apps, apps_version)
+    apps_to_add_to_target = AppsPublisher(factory, publish_tool, ','.join(platforms)).publish(apps, apps_version)
 
     status('Creating Targets that refer to the published Apps; tag: {}, version: {}, machines: {}, platforms: {} '
            .format(target_tag, target_version, ','.join(machines) if machines else '[]',

--- a/tests/test_apps_publisher.py
+++ b/tests/test_apps_publisher.py
@@ -46,7 +46,7 @@ class ComposeAppsPublisherTest(unittest.TestCase):
             yaml.dump(yaml_data, compose_file)
 
         self.apps = ComposeApps(self.apps_root_dir)
-        self.publisher = AppsPublisher(self.factory, self.publish_tool)
+        self.publisher = AppsPublisher(self.factory, self.publish_tool, "")
 
     def tearDown(self):
         shutil.rmtree(self.apps_root_dir)


### PR DESCRIPTION
- Pass a list of platforms (aka architectures) defined in factory-config.yml::containers::platforms, aka factory architectures) to the compose publish tool, so it can shortlist architectures supported by App's images. Otherwise, CI might publish App that supports non-factory architectures what might lead to subtle issues while running App/containers on a device. 

Signed-off-by: Mike Sul <mike.sul@foundries.io>