### PR TITLE
lmp: Use ssh-agent for repo-sync and OE build

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -22,6 +22,26 @@ function git_config {
 	git config user.name 2>/dev/null || git config --global user.name "cibot"
 }
 
+function start_ssh_agent {
+	keys=$(ls /secrets/ssh-*.key 2>/dev/null || true)
+	if [ -n "$keys" ] ; then
+		status Found ssh keys, starting an ssh-agent
+		mkdir -p $HOME/.ssh
+		eval `ssh-agent`
+		for x in $keys ; do
+			echo " Adding $x"
+			key=$HOME/.ssh/$(basename $x)
+			cp $x $key
+			chmod 700 $key
+			ssh-add $key
+		done
+		if [ -f /secrets/ssh-known_hosts ] ; then
+			status " Adding known hosts file"
+			ln -s /secrets/ssh-known_hosts $HOME/.ssh/known_hosts
+		fi
+	fi
+}
+
 function repo_sync {
 	status "Repo syncing sources..."
 

--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -4,20 +4,7 @@ HERE=$(dirname $(readlink -f $0))
 source $HERE/../helpers.sh
 require_params IMAGE
 
-keys=$(ls /secrets/ssh-*.key 2>/dev/null || true)
-if [ -n "$keys" ] ; then
-	status Found ssh keys, starting an ssh-agent
-	eval `ssh-agent`
-	for x in $keys ; do
-		echo " Adding $x"
-		ssh-add $x
-	done
-	if [ -f /secrets/ssh-known_hosts ] ; then
-		status " Adding known hosts file"
-		mkdir -p $HOME/.ssh
-		ln -s /secrets/ssh-known_hosts $HOME/.ssh/known_hosts
-	fi
-fi
+start_ssh_agent
 
 source setup-environment build
 

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -6,6 +6,8 @@ require_params MACHINE IMAGE GIT_SHA
 
 DISTRO="${DISTRO-lmp}"
 
+start_ssh_agent
+
 if [[ $GIT_URL == *"/lmp-manifest.git"* ]]; then
 	status "Build triggered by change to lmp-manifest"
 	manifest="file://$(pwd)/.git -b $GIT_SHA"


### PR DESCRIPTION
Users have both private recipe repositories and private layers. We
have to run two different agents because we repo-sync as root and run
the OE build as "builder".

Signed-off-by: Andy Doan <andy@foundries.io>