### PR TITLE
containers: Add support for Azure private registry

### DIFF
--- a/apps/login_registries
+++ b/apps/login_registries
@@ -29,5 +29,14 @@ for reg in registries:
             subprocess.run(cmd, check=True, input=token)
         except subprocess.CalledProcessError as e:
             sys.exit(e.returncode)
+    elif reg["type"] == "azure":
+        secrets_file = Path("/secrets") / reg["azure_principal_secret_name"]
+        creds = secrets_file.read_text().strip()
+        user, token = creds.split(":")
+        try:
+            cmd = ["docker", "login", "--password-stdin", "-u", user, reg["url"]]
+            subprocess.run(cmd, check=True, input=token.encode())
+        except subprocess.CalledProcessError as e:
+            sys.exit(e.returncode)
     else:
         sys.exit("Unsupported registry type")


### PR DESCRIPTION
The secret contents is expected to be in the format:

 <azure pricipal id>:<azure principal password>

docs.fio will include a corresponding example

Signed-off-by: Andy Doan <andy@foundries.io>