### PR TITLE
apps: align image URI parsing with OCI dist spec

### DIFF
--- a/apps/target_apps_fetcher.py
+++ b/apps/target_apps_fetcher.py
@@ -145,7 +145,7 @@ class SkopeAppFetcher(TargetAppsFetcher):
     def fetch_image(self, target_name: str, arch: str, image: str, dst_root_dir: str):
         logger.info('Pulling image: {}'.format(image))
         uri = self._registry_client.parse_image_uri(image)
-        image_dir = os.path.join(dst_root_dir, uri.host, uri.repo, uri.app, uri.hash)
+        image_dir = os.path.join(dst_root_dir, uri.host, uri.name, uri.hash)
         os.makedirs(image_dir, exist_ok=True)
         subprocess.check_call(['skopeo', '--override-arch', arch, 'copy', '--format', 'v2s2', '--dest-shared-blob-dir',
                                self.blobs_dir(target_name), 'docker://' + image, 'oci:' + image_dir])


### PR DESCRIPTION
- Fix DockerRegistryClient::parse_image_uri so it accepts image URIs
  that contains one or more elements in the `name` (aka `path`) field
  of an image URI. E.g. fiotesting1.azurecr.io/alpine@sha256:<hash>,
  fiotesting1.azurecr.io/library/alpine/latest@sha256:<hash>.

- Adjust DockerRegistryClient::parse_image_uri to the new parsing logic,
 `factory` and `app` fields are mandatory only for images stored in hub.f.io.

- Added unit tests for image URI parsing logic.

Signed-off-by: Mike Sul <mike.sul@foundries.io>