### PR TITLE
lmp: deploy env and logs even in case of failures

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -8,6 +8,11 @@ start_ssh_agent
 
 source setup-environment build
 
-bitbake -D ${IMAGE}
+# Parsing first, to abort in case of parsing issues
+bitbake -p
 
-bitbake -e | grep "^DEPLOY_DIR="| cut -d'=' -f2 | tr -d '"' > deploy_dir
+# Global and image specific envs
+bitbake -e > ${archive}/bitbake_global_env.txt
+bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
+
+bitbake -D ${IMAGE}

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -88,8 +88,11 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
 
 # Bitbake custom logconfig
-BB_LOGCONFIG = "${HERE}/bb_logconfig.json"
+BB_LOGCONFIG = "bb_logconfig.json"
 EOFEOF
+
+# Configure path for the debug/warning logs
+sed -e "s|@@ARCHIVE@@|${archive}|" ${HERE}/bb_logconfig.json > bb_logconfig.json
 
 # Additional packages based on the CI job used
 if [ "$CONF_VERSION" == "1" ]; then

--- a/lmp/bb_logconfig.json
+++ b/lmp/bb_logconfig.json
@@ -14,14 +14,14 @@
         "bitbake_debug": {
             "class": "logging.FileHandler",
             "formatter": "debugFormatter",
-            "filename": "bitbake_debug.log",
+            "filename": "@@ARCHIVE@@/bitbake_debug.log",
             "level": "DEBUG",
             "mode": "w"
         },
         "bitbake_warnings": {
             "class": "logging.FileHandler",
             "formatter": "jsonFormatter",
-            "filename": "bitbake_warning.log",
+            "filename": "@@ARCHIVE@@/bitbake_warning.log",
             "level": "WARNING",
             "mode": "w"
         }


### PR DESCRIPTION
It is quite hard to identify build errors (that are not parsing related)
at the moment, since we don't save the environment and the build log is
only available on successful builds.

Fix by making sure the core files are always stored under ${archive}, as
that folder is always uploaded, even on errors.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>