### PR TITLE
lmp/build: split setscene from main bitbake call

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -15,4 +15,7 @@ bitbake -p
 bitbake -e > ${archive}/bitbake_global_env.txt
 bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
 
+# Setscene (cache), failures not critical
+bitbake --setscene-only ${IMAGE} || true
+
 bitbake -D ${IMAGE}


### PR DESCRIPTION
Failures during setscene are not critical for the build as bitbake can
later rerun those tasks without cache, so separate into a dedicated call
and in a way that won't abort the job execution.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>