### PR TITLE
factory_client: Don't throw when no apps and assembling

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -268,6 +268,10 @@ if __name__ == '__main__':
         for target in targets:
             logger.info('Assembling image for {}, shortlist: {}'.format(target.name, args.app_shortlist))
             subprog = Progress(3, p)
+            if not target.has_apps():
+                logger.info("Target has no apps, skipping preload")
+                subprog.tick(complete=True)
+                continue
             image_file_path, release_info = factory_client.get_target_system_image(target, args.out_image_dir, subprog)
 
             if args.app_type == 'restorable' or (not args.app_type and release_info.lmp_version > 84):

--- a/factory_client.py
+++ b/factory_client.py
@@ -61,6 +61,10 @@ class FactoryClient:
             for app_name, app_desc in apps.items():
                 yield app_name, app_desc['uri']
 
+        def has_apps(self):
+            apps = self['custom'].get('docker_compose_apps')
+            return apps is not None and len(apps) > 0
+
         def _set_apps_commit_hash(self):
             self._apps_commit_hash = None
             if self.apps_uri:


### PR DESCRIPTION
The first time a target is built on a new branch, it may not have any
apps. The assemble-system-image run fails. Ideally we wouldn't execute
this run, but that's kind of difficult to know ahead of time. This
change is a small compromise that will be the image with no apps.

Signed-off-by: Andy Doan <andy@foundries.io>