### PR TITLE
lmp/bb-config: mark all directories as safe for git to read

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -37,6 +37,12 @@ if [ -f "/secrets/targets.sec" ] ; then
 	SOTA_PACKED_CREDENTIALS=$dynamic
 fi
 
+# EULA handling (assume accepted as we now have a click through process when creating the factory)
+EULA_stm32mp1disco="1"
+EULA_stm32mp15disco="1"
+EULA_stm32mp1eval="1"
+EULA_stm32mp15eval="1"
+
 source setup-environment build
 
 if [ "$DEV_MODE" == "1" ]; then


### PR DESCRIPTION
Follow the oe-core change 8bed8e6993e7297bdcd68940aa0d47ef47120117 and
mark all directories as safe for git to read, as a consequence of newer
git releases.

This can later be removed once every factory has a recent enough oe-core
(latest dunfell, honister or kirkstone).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>