### PR TITLE
lmp/build.sh: fix the safe.directory when running the simulator locally

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -49,7 +49,6 @@ function start_ssh_agent {
 function repo_sync {
 	status "Repo syncing sources..."
 
-	git_config
 	if [ -f /secrets/git.http.extraheader ] ; then
 		domain=$(echo $GIT_URL | cut -d/  -f3)
 		status "Adding git config extraheader for $domain"

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -7,6 +7,7 @@ require_params MACHINE IMAGE GIT_SHA
 DISTRO="${DISTRO-lmp}"
 
 start_ssh_agent
+git_config
 
 if [[ $GIT_URL == *"/lmp-manifest.git"* ]]; then
 	status "Build triggered by change to lmp-manifest"


### PR DESCRIPTION
== 2022-06-08 13:38:05 Build triggered by change to lmp-manifest
++ pwd
+ manifest='file:///repo/.git -b cfad3167070e3783cac8c6260e9efa63c952e56c'
+ git branch pr-branch cfad3167070e3783cac8c6260e9efa63c952e56c
fatal: unsafe repository ('/repo' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /repo
Script completed with error(s)

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>