### PR TITLE
lmp: add BITBAKE_EXTRA_ARGS to use additional the bitbake arguments

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -18,4 +18,4 @@ bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
 # Setscene (cache), failures not critical
 bitbake --setscene-only ${IMAGE} || true
 
-bitbake -D ${IMAGE}
+bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}


### PR DESCRIPTION
This will add the option to change the default bitbake arguments using the variable `BITBAKE_EXTRA_ARGS` 

NOTE: currently in the version we have it is already possible to change the default with:
```
ci_scripts:
    url: https://github.com/quaresmajose/ci-scripts
    git_ref: wip
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>