### PR TITLE
lmp/bb-config: accept STM32 EULA by default

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -37,6 +37,12 @@ if [ -f "/secrets/targets.sec" ] ; then
 	SOTA_PACKED_CREDENTIALS=$dynamic
 fi
 
+# EULA handling (assume accepted as we now have a click through process when creating the factory)
+EULA_stm32mp1disco="1"
+EULA_stm32mp15disco="1"
+EULA_stm32mp1eval="1"
+EULA_stm32mp15eval="1"
+
 source setup-environment build
 
 if [ "$DEV_MODE" == "1" ]; then


### PR DESCRIPTION
It is fine to assume they are accepted by default as we now have a click
through process when creating the factory.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>