### PR TITLE
apps: Store App's archive in the blobs dir

### DIFF
--- a/apps/target_apps_fetcher.py
+++ b/apps/target_apps_fetcher.py
@@ -141,6 +141,9 @@ class SkopeAppFetcher(TargetAppsFetcher):
             app_blob_file = os.path.join(app_dir, app_blob_hash + self.ArchiveFileExt)
             with open(app_blob_file, 'wb') as f:
                 f.write(app_blob)
+            # Store the app archive/blob in the blobs directory to simplify fetching
+            with open(os.path.join(blobs_dir, app_blob_hash), 'wb') as f:
+                f.write(app_blob)
 
             with tarfile.open(fileobj=BIO(app_blob)) as t:
                 t.extract('docker-compose.yml', app_dir)


### PR DESCRIPTION
Store an App's archive as a regular image blob in the app store's blobs
directory. It simplifies and unifies fetching of blobs/archives by
aklite/skopeo, specifically, it's useful for an offline update.

Signed-off-by: Mike <mike.sul@foundries.io>