### PR TITLE
apps: Clean up logic around multi arch manifests

### DIFF
--- a/apps/publish.py
+++ b/apps/publish.py
@@ -12,6 +12,7 @@ from apps.target_manager import create_target
 from apps.compose_apps import ComposeApps
 from apps.apps_publisher import AppsPublisher
 from apps.docker_to_compose import convert_docker_apps
+from apps.publish_manifest_lists import publish_manifest_lists
 
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 def main(factory: str, sha: str, targets_json: str, machines: [], platforms: [], app_root_dir: str,
          publish_tool: str, apps_version: str, target_tag: str, target_version: str, new_targets_file: str):
+    publish_manifest_lists()
     convert_docker_apps()
     status('Searching for Compose Apps in {}'.format(app_root_dir))
     apps = ComposeApps(app_root_dir)

--- a/apps/publish_manifest_lists.py
+++ b/apps/publish_manifest_lists.py
@@ -1,0 +1,61 @@
+import json
+import os
+from os.path import expanduser
+
+from helpers import cmd, jobserv_get, status
+from tag_manager import TagMgr
+
+
+def publish_manifest_lists(project: str = "", build_num: str = "", ota_lite_tag: str = ""):
+    if not project:
+        project = os.environ["H_PROJECT"]
+    if not build_num:
+        build_num = os.environ["H_BUILD"]
+    if not ota_lite_tag:
+        ota_lite_tag = os.environ["OTA_LITE_TAG"]
+    factory, _ = project.split("/")
+    latest_tag = TagMgr(ota_lite_tag).tags[0][0]
+
+    status("Publish manifest lists for containers")
+    build = jobserv_get(f"/projects/{project}/builds/{build_num}/")["data"]["build"]
+
+    tags = {}
+
+    manifests_dir = expanduser("~/.docker/manifests")
+    os.makedirs(manifests_dir, exist_ok=True)
+
+    for run in build["runs"]:
+        status(f" Looking for containers built by {run['name']}")
+        run = jobserv_get(run["url"])["data"]["run"]
+        needle = run["url"] + "manifests/"
+        for a in run.get("artifacts"):
+            if a.startswith(needle):
+                _, container_name, _ = a.rsplit("/", 2)
+                tags[container_name] = 1
+                mf = jobserv_get(a)
+                path = os.path.join(manifests_dir, a[len(needle):])
+                try:
+                    os.mkdir(os.path.dirname(path))
+                except FileExistsError:
+                    pass
+                with open(path, "w") as f:
+                    json.dump(mf, f)
+
+    for tag in tags.keys():
+        # docker manifest stores things locally in an odd way (hoping to be
+        # file system friendly perhaps?). It takes a container reference like:
+        #  hub.foundries.io/andy-corp/shellhttpd:215_d8f9e18
+        # and converts the slashes in the path to underscores and the colon
+        # for the tag to a dash. E.g:
+        #  hub.foundries.io_andy-corp_shellhttpd-215_d8f9e18
+        # this logic decodes that from disk so we can understand exactly
+        # what we should publish:
+        mfdir = os.path.join(manifests_dir, tag)
+        names = os.listdir(mfdir)
+        tag = tag.replace(f"_{factory}_", f"/{factory}/")
+        if mfdir.endswith(latest_tag):
+            tag = tag.replace(f"-{latest_tag}", f":{latest_tag}")
+        else:
+            tag = tag.replace(f"-{build_num}_", f":{build_num}_")
+        status(f" Creating {tag} from {names}")
+        cmd("docker", "manifest", "push", tag)


### PR DESCRIPTION
We've had a buggy way of creating multi-arch manifests since the
inception of this tool. This predated docker-manifest and the ability of
CI builds to access artifacts from another run. The issue is that we
build each platform concurrently. Therefore, we don't know which run
is going to complete last and be able to create the multi-arch manifest.

This lead to the ugly hack where we basically did:

 docker manifest create && docker manifest push || true

Only the last run will actually publish the manifest. However, you
periodically have infra issues where the manifest push operation
actually fails. You don't *see* that and we move on the publish run
which will eventually fail to pin this multi-arch reference since it
doesn't exist. Then someone in support has to back-track to find the
source of the issue was one of the other CI Runs.

This change fixes the issue by archiving bits of what
docker-manifest-create does for each CI run. The *publish* run can then
combine them all and *publish* the multi-arch manifests. This has a big
improvement from the previous approach where we created the manifest by
*tags*. This change does by sha256 making it impossible to tamper one of
the tags between the build and publish actions.

This work was almost impossible to do without also fixing:

 https://github.com/foundriesio/ci-scripts/issues/148

That was a long-standing issue broken from the move from the old
"mainfest-tool" and to buildx+ docker-manifest. It has a nice
side-effect in that we no longer need to define "MANIFEST_PLATFORMS" as
we've documented:

 https://docs.foundries.io/latest/reference-manual/docker/containers.html#examples

it was left-over junk from manifest-tool.

Signed-off-by: Andy Doan <andy@foundries.io>