### PR TITLE
Fix tagging issue

### DIFF
--- a/apps/publish_manifest_lists.py
+++ b/apps/publish_manifest_lists.py
@@ -6,6 +6,13 @@ from helpers import cmd, jobserv_get, status
 from tag_manager import TagMgr
 
 
+def compose_tagged_uri(factory: str, org_uri: str, build_num: str, latest_tag: str) -> str:
+    uri = org_uri.replace(f"_{factory}_", f"/{factory}/")
+    tag_pos = uri.rindex("-")
+    uri = uri[:tag_pos] + ':' + uri[tag_pos + 1:]
+    return uri
+
+
 def publish_manifest_lists(project: str = "", build_num: str = "", ota_lite_tag: str = ""):
     if not project:
         project = os.environ["H_PROJECT"]
@@ -55,8 +62,7 @@ def publish_manifest_lists(project: str = "", build_num: str = "", ota_lite_tag:
         # what we should publish:
         mfdir = os.path.join(manifests_dir, tag)
         names = os.listdir(mfdir)
-        tag = tag.replace(f"_{factory}_", f"/{factory}/")
-        tag_pos = tag.rindex("-")
-        tag = tag[:tag_pos] + ':' + tag[tag_pos + 1:]
-        status(f" Creating {tag} from {names}")
-        cmd("docker", "manifest", "push", tag)
+        status(f" Creating tagged URI from {names}; original URI: {tag}, build number: {build_num}, latest tag: {latest_tag}")
+        uri = compose_tagged_uri(factory, tag, build_num, latest_tag)
+        status(f" Pushing manifest to {uri}")
+        cmd("docker", "manifest", "push", uri)

--- a/tests/test_manifest_list_publishing.py
+++ b/tests/test_manifest_list_publishing.py
@@ -1,0 +1,30 @@
+import unittest
+
+from apps.publish_manifest_lists import compose_tagged_uri
+
+
+class ManifestListPublishing(unittest.TestCase):
+    def test_tagged_uri_composing(self):
+        factory = "_devel-arduino_"
+        app_name = "python-_devel-arduino_"
+        build_num = "459"
+        latest_tag = "_devel-arduino_"
+
+        uris = [
+            (
+                f"hub.foundries.io_{factory}_{app_name}-{build_num}_d09aa17",
+                f"hub.foundries.io/{factory}/{app_name}:{build_num}_d09aa17",
+            ),
+            (
+                # `latest_tag` contains dashes
+                # `app_name` contains `latest_tag`
+                # `latest_tag` matches `factory` with underscores
+                f"hub.foundries.io_{factory}_{app_name}-{latest_tag}",
+                f"hub.foundries.io/{factory}/{app_name}:{latest_tag}",
+            )
+        ]
+
+        for u in uris:
+            res_uri = compose_tagged_uri(factory, u[0], build_num, latest_tag)
+            self.assertEqual(u[1], res_uri)
+


### PR DESCRIPTION
apps: Improve image tagging at the publish step
    
- Improve the tagging logic so it takes into account the cases when e
  ref/tag matches an App name and it contains dashes. Also, it should
  fix other odd/edge cases.

- Add a unit test to cover edge cases.
