### PR TITLE
Revert "preload: Fallback to `docker-compose` if no `docker compose`"

### DIFF
--- a/apps/compose_apps.py
+++ b/apps/compose_apps.py
@@ -38,10 +38,7 @@ class ComposeApps:
             self._image_downloader_cls = image_downloader_cls
 
             args = [self.DockerComposeTool, 'compose', '-f', self.ComposeFile, 'config']
-            try:
-                cmd_exe(*args, cwd=self.dir)
-            except FileNotFoundError:
-                cmd_exe('docker-compose', '-f', self.ComposeFile, 'config', cwd=self.dir)
+            cmd_exe(*args, cwd=self.dir)
 
             with open(self.file) as compose_file:
                 self._desc = yaml.safe_load(compose_file)


### PR DESCRIPTION
This reverts commit 5b931369c0cce7d2aee4fff2f2a842d0145d29c3 since `docker compose` is available in the `lmp-sdk` container now, see https://github.com/foundriesio/lmp-manifest/pull/208.