### PR TITLE
lmp/jobserv: the stable branch is now kirkstone

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -178,7 +178,7 @@ triggers:
       GIT_URL: |
         https://github.com/foundriesio/lmp-manifest.git
       GIT_POLL_REFS: |
-        refs/heads/honister
+        refs/heads/kirkstone
       OTA_LITE_TAG: 'postmerge-stable:postmerge'
       AKLITE_TAG: promoted-stable
     runs:


### PR DESCRIPTION
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>