### PR TITLE
lmp/bb-config: accepte the synaptics-killswitch license on raspberrypi

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -65,6 +65,7 @@ ACCEPT_EULA:stm32mp1-disco = "1"
 ACCEPT_EULA:stm32mp1-eval = "1"
 ACCEPT_EULA:stm32mp15-disco = "1"
 ACCEPT_EULA:stm32mp15-eval = "1"
+LICENSE_FLAGS_ACCEPTED:append:rpi = " synaptics-killswitch"
 EOFEOF
 fi
 


### PR DESCRIPTION
fixes the following issue:

```
| ERROR: Nothing RPROVIDES 'linux-firmware-rpidistro-bcm43455' (but /srv/oe/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb, /srv/oe/build/conf/../../layers/openembedded-core/meta/recipes-core/packagegroups/packagegroup-base.bb RDEPENDS on or otherwise requires it)
| linux-firmware-rpidistro RPROVIDES linux-firmware-rpidistro-bcm43455 but was skipped: because it has a restricted license 'synaptics-killswitch'. Which is not listed in LICENSE_FLAGS_ACCEPTED
| ERROR: Required build target 'lmp-base-console-image' has no buildable providers.
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>