### PR TITLE
lmp/build.sh: allow EXTRA_ARTIFACTS to be optional

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -164,7 +164,7 @@ if [ -d "${archive}" ] ; then
 	# Handle user provided extra artifacts
 	if [ ! -z "${EXTRA_ARTIFACTS}" ]; then
 		for extra_file in ${EXTRA_ARTIFACTS}; do
-			cp ${DEPLOY_DIR_IMAGE}/${extra_file} ${archive}/
+			cp ${DEPLOY_DIR_IMAGE}/${extra_file} ${archive}/ || true
 		done
 	fi
 


### PR DESCRIPTION
In some cases, mutliple different machines are built where only some have the extra artifacts that are specified.  Let's not break the build when these are missing.

Signed-off-by: Michael Scott <mike@foundries.io>