### PR TITLE
lmp: use kirsktone machine names for stm32mp1

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -222,8 +222,8 @@ triggers:
         params:
           IMAGE: lmp-base-console-image
           MFGTOOL_FLASH_IMAGE: lmp-base-console-image
-          EULA_stm32mp1eval: "1"
-          EULA_stm32mp1disco: "1"
+          EULA_stm32mp15eval: "1"
+          EULA_stm32mp15disco: "1"
         script-repo:
           name: fio
           path: lmp/build.sh


### PR DESCRIPTION
Use kirkstone machine names for stm32mp1.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>