### PR TITLE
apps: Build containers with two labels

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -51,6 +51,10 @@ if [ -n "$DOCKER_BUILDX" ] ; then
 	docker_build="docker buildx build"
 fi
 
+TAG=$(git log -1 --format=%h)
+LATEST=${OTA_LITE_TAG-"latest"}
+LATEST=$(echo $LATEST | cut -d: -f1 | cut -d, -f1)  # Take into account advanced tagging
+
 pbc=pre-build.conf
 if [ -f $pbc ] ; then
   echo "Sourcing pre-build.conf."
@@ -66,10 +70,6 @@ if [ -z "$IMAGES" ] ; then
 	IMAGES=$(find ./ -mindepth 2 -maxdepth 2 -name Dockerfile | cut -d / -f2)
 fi
 
-
-TAG=$(git log -1 --format=%h)
-LATEST=${OTA_LITE_TAG-"latest"}
-LATEST=$(echo $LATEST | cut -d: -f1 | cut -d, -f1)  # Take into account advanced tagging
 
 if [ -f /secrets/osftok ] ; then
 	mkdir -p $HOME/.docker
@@ -147,7 +147,7 @@ for x in $IMAGES ; do
 		status Tagging docker image $x for $ARCH
 		run docker tag ${ct_base}:${LATEST} ${ct_base}:$TAG-$ARCH
 	else
-		docker_cmd="$docker_build -t ${ct_base}:$TAG-$ARCH --force-rm"
+		docker_cmd="$docker_build -t ${ct_base}:$TAG-$ARCH -t ${ct_base}:$LATEST-$ARCH --force-rm"
 		if [ -z "$NOCACHE" ] ; then
 			status Building docker image $x for $ARCH with cache
 			docker_cmd="$docker_cmd  --cache-from ${ct_base}:${LATEST}"


### PR DESCRIPTION
We have a problem with factories using a common base image as described:

 https://docs.foundries.io/88/reference-manual/docker/containers.html#id1

Currently, every build is causing the images that extend the base image to be "rebuilt". I say that in quotes because its still the same image: every single layer the image is made from remains the same. However, the docker manifest pointing to the layers does change.

This comes from my misunderstanding of the "FROM" line in the child containers. Our docs have have basically inherit from base:${tag}-${arch}. ${tag} is changing every single build. While the SHA256 it points to does not change, the logic of a Dockerfile to decide what to build more or less does a string equals comparison of each line of the Dockerfile. This causes things to rebuild.

We instead need the child containers to have a consistent FROM line:

 ${LATEST}-${arch}

This tag isn't changing but its *sha* will when the base image changes.

This fix moves the logic to evaluate LATEST before we source pre-build.conf and then have ci publish two tags for each container we build:

 ${tag}-${arch}    - what we've always had
 ${LATEST}-${arch} - the one we need for base images

NOTE: This allows things to work we still have to fix:

 * factories that use this. Pre-build.conf needs a change to have: `_base_img="hub.foundries.io/${FACTORY}/0base:$LATEST-$ARCH"`

 * documentation that fixes the pre-build.conf template

Signed-off-by: Andy Doan <andy@foundries.io>