### PR TITLE
apps: Handle git-sha collision bug in tagging

### DIFF
--- a/apps/publish_manifest_lists.py
+++ b/apps/publish_manifest_lists.py
@@ -18,8 +18,11 @@ def compose_tagged_uri(factory: str, org_uri: str, build_num: str, latest_tag: s
         uri = uri[:latest_tag_indx] + f":{latest_tag}"
         return uri
 
+    # find the git-hash length. Its usually 7, but can be 8 when you hit hash
+    # collisions
+    hash_idx = uri.rfind("_")
     build_num_case = f"-{build_num}_"
-    build_num_indx = uri.rfind(build_num_case, len(uri) - (len(build_num_case) + 7))
+    build_num_indx = uri.rfind(build_num_case, len(uri) - (hash_idx-1)- (len(build_num_case)))
     if build_num_indx != -1:
         uri = uri[:build_num_indx] + ":" + uri[build_num_indx + 1:]
         return uri

--- a/tests/test_manifest_list_publishing.py
+++ b/tests/test_manifest_list_publishing.py
@@ -16,6 +16,10 @@ class ManifestListPublishing(unittest.TestCase):
                 f"hub.foundries.io/{factory}/{app_name}:{build_num}_d09aa17",
             ),
             (
+                f"hub.foundries.io_{factory}_{app_name}-{build_num}_d09aa17a",
+                f"hub.foundries.io/{factory}/{app_name}:{build_num}_d09aa17a",
+            ),
+            (
                 # `latest_tag` contains dashes
                 # `app_name` contains `latest_tag`
                 # `latest_tag` matches `factory` with underscores


### PR DESCRIPTION
Our logic was hard-coded to assume Git SHA's are always 7 long. Git SHAs can sometimes collide in the first 7 characters leading the hash to be longer.

This change dynamically determines the SHA length so that we can handle all input.

Signed-off-by: Andy Doan <andy@foundries.io>