### PR TITLE
lmp/build: remove ota-ext4 when ota-ext4.gz is available

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -168,6 +168,11 @@ if [ -d "${archive}" ] ; then
 		done
 	fi
 
+	# Remove ota-ext4 in case the compressed format is available (to reduce time spent uploading)
+	if [ -f ${archive}/other/${IMAGE}-${MACHINE}.ota-ext4.gz ]; then
+		rm -f ${archive}/other/${IMAGE}-${MACHINE}.ota-ext4
+	fi
+
 	# Make the main img.gz be in the root of the archive
 	mv ${archive}/other/lmp-*.wic.gz ${archive}/ || true
 	# NVIDIA targets use a tegraflash tarball


### PR DESCRIPTION
Ota-ext4 can be quite big depending on the machine used (e.g. jetson agx has a 28GB ota-ext4 file), so make sure to remove it if the compressed format is available.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>