### PR TITLE
Enable buildx explicitly and remove legacy logic

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -90,22 +90,6 @@ for x in $IMAGES ; do
 		. $conf
 	fi
 
-	# If NOCACHE is not set, only build images that have changed.
-	if [ -z "$NOCACHE" ] ; then
-		no_op_tag=0
-		# If we are using buildx, don't try to guess what has changed
-		if [ -z "$DOCKER_BUILDX" ] ; then
-			# If we cannot obtain the diff, force the build
-			CHANGED=$(git diff --name-only $GIT_OLD_SHA..$GIT_SHA $x/${BUILD_CONTEXT} || echo FORCE_BUILD)
-			if [[ ! -z "$CHANGED" ]]; then
-				status "Detected changes to $x"
-			else
-				status "No changes to $x, tagging only"
-				no_op_tag=1
-			fi
-		fi
-	fi
-
 	# check to see if we should skip building this image`
 	found=0
 	for a in $SKIP_ARCHS ; do

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -179,13 +179,6 @@ for x in $IMAGES ; do
 	echo "Build step $((completed+1)) of $total is complete"
 
 	if [ $auth -eq 1 ] ; then
-		if [[ -z "$DOCKER_BUILDX" ]] || [[ $no_op_tag -eq 1 ]] ; then
-			# if docker secrets doesn't exist, we aren't using buildx - we need to push
-			# if secrets are defined but no_op_tag is 1, then we didn't build with
-			# buildx and need to push
-			run docker push ${ct_base}:$TAG-$ARCH
-		fi
-
 		run docker manifest create ${ct_base}:${H_BUILD}_$TAG ${ct_base}:$TAG-$ARCH
 		run docker manifest create ${ct_base}:${LATEST} ${ct_base}:$TAG-$ARCH
 

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -16,6 +16,7 @@ HERE=$(dirname $(readlink -f $0))
 
 require_params FACTORY
 
+export DOCKER_BUILDKIT=1
 BUILDKIT_VERSION="${BUILDKIT_VERSION-v0.10.3}"
 
 MANIFEST_PLATFORMS_DEFAULT="${MANIFEST_PLATFORMS_DEFAULT-linux/amd64,linux/arm,linux/arm64}"
@@ -140,18 +141,13 @@ for x in $IMAGES ; do
 		if [ -z "$NOCACHE" ] ; then
 			status Building docker image $x for $ARCH with cache
 			docker_cmd="$docker_cmd  --cache-from ${ct_base}:${LATEST}"
-			if [ -n "$DOCKER_BUILDX" ] ; then
-				docker_cmd="${docker_cmd}-${ARCH}_cache"
-			fi
+			docker_cmd="${docker_cmd}-${ARCH}_cache"
 		else
 			status Building docker image $x for $ARCH with no cache
 			docker_cmd="$docker_cmd  --no-cache"
 		fi
 
-		if [ -n "$DOCKER_BUILDX" ] ; then
-			export DOCKER_BUILDKIT=1
-			docker_cmd="$docker_cmd --push --cache-to type=registry,ref=${ct_base}:${LATEST}-${ARCH}_cache,mode=max"
-		fi
+		docker_cmd="$docker_cmd --push --cache-to type=registry,ref=${ct_base}:${LATEST}-${ARCH}_cache,mode=max"
 
 		if [ -n "$DOCKER_SECRETS" ] ; then
 			status "DOCKER_SECRETS defined - building --secrets for $(ls /secrets)"

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -129,11 +129,6 @@ for x in $IMAGES ; do
 	if [ -f /secrets/osftok ] ; then
 		status "Doing docker-login to hub.foundries.io with secret"
 		docker login hub.foundries.io --username=doesntmatter --password=$(cat /secrets/osftok) | indent
-		# sanity check and pull in a cached image if it exists. if it can't be pulled set no_op_tag to 0.
-		run docker pull ${ct_base}:${LATEST} || no_op_tag=0
-		if [ $no_op_tag -eq 0 ] && [ -z "$CHANGED" ] && [ -z "$DOCKER_BUILDX" ] ; then
-			status "WARNING - no cached image found, forcing a rebuild"
-		fi
 		auth=1
 	fi
 

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -43,7 +43,6 @@ for i in `seq 12` ; do
 	fi
 done
 
-DOCKER_BUILDX="1"
 docker_build="docker buildx build"
 
 TAG=$(git log -1 --format=%h)

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -42,14 +42,8 @@ for i in `seq 12` ; do
 	fi
 done
 
-docker_build="docker build"
-if [ -n "$DOCKER_SECRETS" ] ; then
-	# secrets require buildx
-	DOCKER_BUILDX="1"
-fi
-if [ -n "$DOCKER_BUILDX" ] ; then
-	docker_build="docker buildx build"
-fi
+DOCKER_BUILDX="1"
+docker_build="docker buildx build"
 
 TAG=$(git log -1 --format=%h)
 LATEST=${OTA_LITE_TAG-"latest"}


### PR DESCRIPTION
Our logic for building containers predates buildx. We eventually started doing buildx and moving customers over one by. Turns out, we didn't migrate one of our oldest customers. They are now needing something buildx offers. This change set makes us use buildx. It's safe because everyone else was already on it. While enforcing buildx, I was able to remove a lot of old conditional logic that simply can't be run now.