### PR TITLE
Revert "lmp/jobserv.yml: install aktualizr-lite-public-stream by default"

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -531,7 +531,6 @@ params:
   archive: /archive
   DISTRO: lmp
   SOTA_CLIENT: aktualizr-lite
-  EXTRA_IMAGE_INSTALL: aktualizr-lite-public-stream
   OSTREE_BRANCHNAME: lmp
 
 script-repos:


### PR DESCRIPTION
This reverts commit 76f9596a83856c48a6ca9a6a13bc6fac4c0a1d98.
    
We don't publish targets anymore.
    
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
