### PR TITLE
LmP: refactor INHERIT build config

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -229,8 +229,6 @@ EOFEOF
 fi
 
 cat << EOFEOF >> conf/auto.conf
-# get build stats to make sure that we use sstate properly
-INHERIT += "buildstats buildstats-summary"
 
 # archive sources for target recipes (for license compliance)
 INHERIT += "archiver"

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -237,6 +237,15 @@ ARCHIVER_MODE[src] = "original"
 ARCHIVER_MODE[diff] = "1"
 EOFEOF
 
+# spdx is support since kirkstone so check if this oe-core have support
+if [ -f ../layers/openembedded-core/meta/classes/create-spdx.bbclass ]; then
+	cat << EOFEOF >> conf/auto.conf
+
+# create SPDX (SBOM) documents
+INHERIT += "create-spdx"
+EOFEOF
+fi
+
 if [ $(ls ../sstate-cache | wc -l) -ne 0 ] ; then
 	status "Found existing sstate cache, using local copy"
 	echo 'SSTATE_MIRRORS = ""' >> conf/auto.conf


### PR DESCRIPTION
**Buildstats**
The buildstats option is only enabled on the CI build but it is very useful in local builds as well to check sstate-cache usage.


**Create-spdx**
The create-spdx is been moved to only runs on CI as local builds can run in the majority of time without this
that reduces the build time.