### PR TITLE
lmp: Fix logic for detecting the base version

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -32,15 +32,8 @@ fi
 cat /root/.gitconfig >>  /home/builder/.gitconfig
 cp /root/.netrc /home/builder/.netrc || true
 
-# Detect the base LmP version we are building on
-run git --git-dir .repo/manifests.git remote add upstream https://github.com/foundriesio/lmp-manifest
-run git --git-dir .repo/manifests.git fetch --tags upstream
-export LMP_VER=$(git --git-dir .repo/manifests.git describe upstream/main --tags --abbrev=0)
-if [[ "${H_PROJECT}" == "lmp" ]] ; then
-	# Public LmP build - we are building for the *next* release
-	LMP_VER=$(( $LMP_VER + 1 ))
-fi
-status "Base LmP version detected as: $LMP_VER"
+
+set_base_lmp_version
 
 mkdir build conf
 cache="/var/cache/bitbake/v${LMP_VER}-downloads"

--- a/tests/test_lmp_base_version.sh
+++ b/tests/test_lmp_base_version.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -euo pipefail
+
+HERE=$(dirname $(readlink -f $0))
+source ${HERE}/../helpers.sh
+
+tmpdir=$(mktemp -d)
+trap "echo removing tmpdir; rm -rf $tmpdir" TERM INT EXIT
+
+cd $tmpdir
+mkdir .repo
+
+# Create a fake customer lmp-manifest
+run git clone https://github.com/foundriesio/lmp-manifest fake
+# Move to a commit after 88 and before 89
+run git --git-dir fake/.git tag v123 d0bf3844aabce3028969fda2c3fd3f443ae3b4f7
+run git --git-dir fake/.git reset --hard d0bf3844aabce3028969fda2c3fd3f443ae3b4f7
+
+run git clone fake .repo/manifests
+mv .repo/manifests/.git .repo/manifests.git
+
+export H_PROJECT="andy-corp/lmp"
+set_base_lmp_version
+if [[ "$LMP_VER" != "88" ]] ; then
+	echo "ERROR: LMP_VER != 88 - ${LMP_VER}"
+	exit 1
+fi
+
+latest=$(git --git-dir .repo/manifests.git describe --tag)
+if [[ "$latest" != "v123" ]] ; then
+	echo "ERROR: latest tag != v123 - $latest"
+	exit 1
+fi
+
+run git --git-dir .repo/manifests.git remote remove upstream
+export H_PROJECT="lmp"
+set_base_lmp_version
+if [[ "$LMP_VER" != "89" ]] ; then
+	echo "ERROR: LMP_VER != 89 - ${LMP_VER}"
+	exit 1
+fi


### PR DESCRIPTION
Its a little tricky to pick up the base LmP version. We need to make sure we've fetched tags from the public LmP and *don't* look at tags that have been created by the user.

The old version was also getting the *latest* tag which is currently v89 but that's probably not the actual LmP version the customer is building with. Git doesn't have a way to distinguish where tags come from, so the easiest thing to do is just delete all the tags and then pull from our official tags.

Signed-off-by: Andy Doan <andy@foundries.io>