### PR TITLE
apps: Set default targets expiration to one month

### DIFF
--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -95,7 +95,7 @@ status "Publishing apps; version: ${APPS_VERSION}, Target tag: ${TARGET_TAG}"
 cp "${TUF_REPO}/roles/unsigned/targets.json" "${ARCHIVE}/targets-after.json"
 
 echo "Signing local TUF targets"
-run garage-sign targets sign --repo "${TUF_REPO}" --key-name targets
+run garage-sign targets sign --repo "${TUF_REPO}" --key-name targets --expire-after 1M
 
 if [ "${PUSH_TARGETS}" ]; then
   echo "Publishing local TUF targets to the remote TUF repository"


### PR DESCRIPTION
The newer version of `garage-sign` does not refresh targets meta expiration by default as it's used to be in the older versions. So, let's set the expiration value to one month explicitly in the `garage-sign` command call.
The same already happens in the LmP build too, see `meta-updater/classes/image_types_ostree.bbclass`.

Signed-off-by: Mike <mike.sul@foundries.io>