### PR TITLE
Adds support to use the HTTP sstate cache mirror on the factories

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -94,7 +94,7 @@ function set_base_lmp_version {
 	# 3: Find our base LMP version based on the HEAD
 	export LMP_VERSION=$(git describe --tags --abbrev=0 HEAD)
 	export LMP_VERSION_CACHE="$LMP_VERSION"
-	if [[ "${H_PROJECT}" == "lmp" ]] ; then
+	if [[ "${H_PROJECT}" == "lmp" ]] || [ -v LMP_VERSION_CACHE_DEV ] ; then
 		# Public LmP build - we are building for the *next* release
 		LMP_VERSION_CACHE=$(( $LMP_VERSION_CACHE + 1 ))
 	fi

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -211,11 +211,6 @@ if [ -d "$SSTATE_CACHE_MIRROR" ]; then
 SSTATE_MIRRORS = "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
 EOFEOF
 fi
-if [[ "$SSTATE_CACHE_MIRROR" == "https://"* ]]  ; then
-	cat << EOFEOF >> conf/local.conf
-SSTATE_MIRRORS = "file://.* ${SSTATE_CACHE_MIRROR}/v$LMP_VERSION_CACHE-sstate-cache/PATH"
-EOFEOF
-fi
 
 # Add build id H_BUILD to output files names
 if [ "$CONF_VERSION" == "1" ]; then

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -208,7 +208,7 @@ fi
 
 if [ -d "$SSTATE_CACHE_MIRROR" ]; then
 	cat << EOFEOF >> conf/local.conf
-SSTATE_MIRRORS = "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
+SSTATE_MIRRORS ?= "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
 EOFEOF
 fi
 

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -241,11 +241,6 @@ INHERIT += "create-spdx"
 EOFEOF
 fi
 
-if [ $(ls ../sstate-cache | wc -l) -ne 0 ] ; then
-	status "Found existing sstate cache, using local copy"
-	echo 'SSTATE_MIRRORS = ""' >> conf/auto.conf
-fi
-
 for x in $(ls conf/*.conf) ; do
 	status "$x"
 	cat $x | indent

--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -623,7 +623,6 @@ params:
   SOTA_CLIENT: aktualizr-lite
   SOTA_TUF_ROOT_PROVISION: "0"
   OSTREE_BRANCHNAME: lmp
-  SSTATE_CACHE_MIRROR: https://storage.googleapis.com/lmp-cache
 
 script-repos:
   fio:


### PR DESCRIPTION
The variable `SSTATE_CACHE_MIRROR` is to force the use of the public LmP HTTP ssate cache mirror: 
```
# factory-config.yml

  params:
    IMAGE: lmp-factory-image
    SSTATE_CACHE_MIRROR: ""
```

The variable `LMP_VERSION_CACHE_DEV` is to use the development version of the cache: 
```
# factory-config.yml

  params:
    IMAGE: lmp-factory-image
    SSTATE_CACHE_MIRROR: ""
    LMP_VERSION_CACHE_DEV: ""
```
