### PR TITLE
helpers: re-run repo init on loop to avoid ci failures

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -54,7 +54,13 @@ function repo_sync {
 		status "Adding git config extraheader for $domain"
 		git config --global http.https://${domain}.extraheader "$(cat /secrets/git.http.extraheader)"
 	fi
-	run repo init --repo-rev=v2.29.4 --no-clone-bundle -u $* ${REPO_INIT_OVERRIDES}
+	for i in $(seq 4); do
+		run repo init --repo-rev=v2.29.4 --no-clone-bundle -u $* ${REPO_INIT_OVERRIDES} && break
+		status "repo init failed with error $?"
+		[ $i -eq 4 ] && exit 1
+		status "sleeping and trying again"
+		sleep $(($i*2))
+	done
 	for i in $(seq 4); do
 		run timeout 4m repo sync && break
 		if [ $? -eq 124 ] ; then


### PR DESCRIPTION
Sometimes repo init fails sporadically and this will abort the ci job.
To avoid such situation we can try again to run the command with a random sleep in between.

```
|== 2023-01-11 21:29:51 Running: repo init --repo-rev=v2.29.4 --no-clone-bundle -u file:///repo/.git -b baaff135ea1b0d04f6657944d755a14c1f772d72 |  repo: error: "git" failed with exit status 128
|    cwd: /srv/oe/.repo/repo
|    cmd: ['git', 'fetch', '--quiet', 'origin', '+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']
|    stderr:
|    >> fatal: unable to access 'https://gerrit.googlesource.com/git-repo/': gnutls_handshake() failed: The TLS connection was non-properly terminated.
|  fatal: cloning the git-repo repository failed, will remove '.repo/repo'
|  Downloading Repo source from https://gerrit.googlesource.com/git-repo
|--
|Script completed with error(s)
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>