### PR TITLE
preloading: Strip quotation mark in VERSION

### DIFF
--- a/factory_client.py
+++ b/factory_client.py
@@ -83,7 +83,7 @@ class FactoryClient:
         def parse(cls, release_info: dict) -> 'Release':
             # VERSION="3.3.4-1147-84-270-gd10167f",
             # <yocto-version>-<commit-numb-after-tag>-<lmp-version>-<commit-numb-after-tag>-<abbreviated commit hash>
-            version = release_info['VERSION']
+            version = release_info['VERSION'].strip('"')
             version_data = version.split('-')
             lmp_version = int(version_data[2]) if len(version_data) > 2 else 0
             yocto_version = version_data[0] if len(version_data) >= 1 else None


### PR DESCRIPTION
Remove leading and trailing `"` symbol from the `VERSION` value extracted from `os-release`.
For some reason, the LmP started adding them recently.

Signed-off-by: Mike <mike.sul@foundries.io>