### PR TITLE
lmp/jobserv: disable SOTA_TUF_ROOT_PROVISION

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -621,6 +621,7 @@ params:
   archive: /archive
   DISTRO: lmp
   SOTA_CLIENT: aktualizr-lite
+  SOTA_TUF_ROOT_PROVISION: 0
   OSTREE_BRANCHNAME: lmp
   SSTATE_CACHE_MIRROR: https://storage.googleapis.com/lmp-cache
 


### PR DESCRIPTION
No need for provisioning TUF metadata on the public lmp factory, we don't publish targets anymore.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>