### PR TITLE
lmp/jobserv: in yaml, strings don't need quotes but numbers do

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -621,7 +621,7 @@ params:
   archive: /archive
   DISTRO: lmp
   SOTA_CLIENT: aktualizr-lite
-  SOTA_TUF_ROOT_PROVISION: 0
+  SOTA_TUF_ROOT_PROVISION: "0"
   OSTREE_BRANCHNAME: lmp
   SSTATE_CACHE_MIRROR: https://storage.googleapis.com/lmp-cache
 


### PR DESCRIPTION
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>