### PR TITLE
lmp/bb-config: use a weak assign for the SSTATE_MIRRORS

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -238,11 +238,6 @@ ARCHIVER_MODE[src] = "original"
 ARCHIVER_MODE[diff] = "1"
 EOFEOF
 
-if [ $(ls ../sstate-cache | wc -l) -ne 0 ] ; then
-	status "Found existing sstate cache, using local copy"
-	echo 'SSTATE_MIRRORS = ""' >> conf/auto.conf
-fi
-
 for x in $(ls conf/*.conf) ; do
 	status "$x"
 	cat $x | indent

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -210,8 +210,7 @@ if [ -d $SSTATE_CACHE_MIRROR ]; then
 	cat << EOFEOF >> conf/local.conf
 SSTATE_MIRRORS = "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
 EOFEOF
-fi
-if [[ "$SSTATE_CACHE_MIRROR" == "https://"* ]]  ; then
+elif [[ "$SSTATE_CACHE_MIRROR" == "https://"* ]]  ; then
 	cat << EOFEOF >> conf/local.conf
 SSTATE_MIRRORS = "file://.* ${SSTATE_CACHE_MIRROR}/v$LMP_VERSION_CACHE-sstate-cache/PATH"
 EOFEOF

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -208,11 +208,11 @@ fi
 
 if [ -d $SSTATE_CACHE_MIRROR ]; then
 	cat << EOFEOF >> conf/local.conf
-SSTATE_MIRRORS = "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
+SSTATE_MIRRORS ?= "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
 EOFEOF
 elif [[ "$SSTATE_CACHE_MIRROR" == "https://"* ]]  ; then
 	cat << EOFEOF >> conf/local.conf
-SSTATE_MIRRORS = "file://.* ${SSTATE_CACHE_MIRROR}/v$LMP_VERSION_CACHE-sstate-cache/PATH"
+SSTATE_MIRRORS ?= "file://.* ${SSTATE_CACHE_MIRROR}/v$LMP_VERSION_CACHE-sstate-cache/PATH"
 EOFEOF
 fi
 


### PR DESCRIPTION
This add the possibility to disable or changing the sstate mirror with a simple assignment:

SSTATE_MIRRORS = ""

or

SSTATE_MIRRORS = "http://use-this-one-instated"

If for some reason the sstate cache on the mirror is corrupted we can do a build without using it.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>