### PR TITLE
lmp/bb-build: since lmp v87 the setscene-only is not need anymore

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -15,8 +15,11 @@ bitbake -p
 bitbake -e > ${archive}/bitbake_global_env.txt
 bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
 
-# Setscene (cache), failures not critical
-bitbake --setscene-only ${IMAGE} || true
+# Before LmP version 87 (first release with OE-core kirkstone),
+# this is need to avoid build failures that can recover in the next steps
+if [ "$LMP_VERSION" -lt "87" ]; then
+    bitbake --setscene-only ${IMAGE} || true
+fi
 
 if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
     bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE} -c populate_sdk


### PR DESCRIPTION
If we have failing setscene tasks is because our sstate cache is broken and needs to be fixed. When this happens bitbake can take care of the of the failed setscene tasks running again the real task.

Running bitbake with '--setscene-only' doesn't help in this case because when the setscene task fails, the new one stored on the sstate-cache will only be updated after running the real task.
To do that bitbake needs to run without '--setscene-only', that is what is done on the on the second bitbake call, otherwise bitbake will get the setscene task again from the sstate-cache.

This also makes more clear the sstate-cache usage in the CI because currently is not possible to see it in a clear way because in the first bitbake call the sstate-cache reuse is 100% and on the second call is 0%.

The main reason to have this is to avoid build failure when the setcene task fails but these issue is been fixed with [1] and backported to kirkstone with [2]

[1] - https://git.yoctoproject.org/poky/commit/meta/classes/sstate.bbclass?id=77f08932f4bc927b506130aa2dde4936a379ff1f
[2] - https://git.yoctoproject.org/poky/commit/meta/classes/sstate.bbclass?h=kirkstone&id=77f08932f4bc927b506130aa2dde4936a379ff1f

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>