### PR TITLE
assembly: Handle shortlist with spaces

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -265,10 +265,10 @@ def get_args():
     args = parser.parse_args()
 
     if args.targets:
-        args.targets = args.targets.split(',')
+        args.targets = [x.strip() for x in args.targets.split(',') if x]
 
     if args.app_shortlist:
-        args.app_shortlist = args.app_shortlist.split(',')
+        args.app_shortlist = [x.strip() for x in args.app_shortlist.split(',') if x]
 
     return args
 


### PR DESCRIPTION
Our current logic requires shortlist and targets to be a comma seperated list with no spaces:

 "1,2,3"

This change allows it to deal with whitespace like:

 " 1, 2, 3 "

Signed-off-by: Andy Doan <andy@foundries.io>