### PR TITLE
lmp/bb-config: fix zero length SSTATE_CACHE_MIRROR directory test

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -206,7 +206,7 @@ IMAGE_LICENSE_CHECKER_NON_ROOTFS_DENYLIST = "GPL-3.0-only GPL-3.0-or-later LGPL-
 EOFEOF
 fi
 
-if [ -d $SSTATE_CACHE_MIRROR ]; then
+if [ -d "$SSTATE_CACHE_MIRROR" ]; then
 	cat << EOFEOF >> conf/local.conf
 SSTATE_MIRRORS = "file://.* file://${SSTATE_CACHE_MIRROR}/PATH"
 EOFEOF


### PR DESCRIPTION
When the length of SSTATE_CACHE_MIRROR is zero the check is not evaluated correctly.

Can be tested with:
```
T=$(mktemp)
cat << 'EOF' > $T
echo -
if [ -d "$1" ]; then echo " OK "; fi
if [ -d $1   ]; then echo "FAIL"; fi
EOF
sh $T /tmp
sh $T ""
sh $T 
```
