### PR TITLE
lmp/bb-config: use the full path for the bb_logconfig.json

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -137,7 +137,7 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
 
 # Bitbake custom logconfig
-BB_LOGCONFIG = "bb_logconfig.json"
+BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
 EOFEOF
 
 # Configure path for the debug/warning logs


### PR DESCRIPTION
Some tools like oe-selftest requires the full path as it runs on a relocated build path.