### PR TITLE
lmp/bb-build: run buildstats-summary at the end

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -25,3 +25,20 @@ if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
     bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE} -c populate_sdk
 fi
 bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}
+
+# write a summary of the buildstats to the terminal
+BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
+if [ -f $BUILDSTATS_SUMMARY ]; then
+    BUILDSTATS_PATH="$(bitbake-getvar --value TMPDIR | tail -n 1)/buildstats"
+    if [ -d $BUILDSTATS_PATH ]; then
+        # get the most recent folder
+        BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+        # common arguments with bold disabled
+        BUILDSTATS_SUMMARY="$BUILDSTATS_SUMMARY --sort duration --highlight 0"
+        # log all task
+        $BUILDSTATS_SUMMARY $BUILDSTATS_PATH > ${archive}/bitbake_buildstats.log
+        # for console hide tasks < Seconds
+        BUILDSTATS_SUMMARY="$BUILDSTATS_SUMMARY --shortest 60"
+        run $BUILDSTATS_SUMMARY $BUILDSTATS_PATH
+    fi
+fi

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -58,7 +58,7 @@ chown -R builder .
 
 su builder -c $HERE/bb-config.sh
 touch ${archive}/customize-target.log && chown builder ${archive}/customize-target.log
-touch ${archive}/bitbake_debug.log ${archive}/bitbake_warning.log && chown builder ${archive}/bitbake_*.log
+touch ${archive}/bitbake_debug.log ${archive}/bitbake_warning.log ${archive}/bitbake_buildstats.log && chown builder ${archive}/bitbake_*.log
 touch ${archive}/bitbake_global_env.txt ${archive}/bitbake_image_env.txt && chown builder ${archive}/bitbake_*_env.txt
 touch ${archive}/app-preload.log && chown builder ${archive}/app-preload.log
 touch ${archive}/tuf-root-fetch.log && chown builder ${archive}/tuf-root-fetch.log
@@ -127,6 +127,7 @@ if [ -d "${archive}" ] ; then
 	gzip -f ${archive}/bitbake_debug.log
 	mv ${archive}/bitbake_debug.log.gz ${archive}/other/
 	mv ${archive}/bitbake_warning.log ${archive}/other/
+	mv ${archive}/bitbake_buildstats.log ${archive}/other/
 
 	# Compress and publish source tarball (for *GPL* packages)
 	if [ -d ${DEPLOY_DIR_IMAGE}/source-release ]; then


### PR DESCRIPTION
This script [1] will write a summary of the buildstats to the terminal, sorted by start time or duration, optionally hiding short tasks, and highlighting long running tasks.

[1] https://git.yoctoproject.org/poky/commit/?id=1908193b81a1a5dbe04ccf296c2daa15bfac7000