### PR TITLE
Add support to run the oe-selftest on the factory

### DIFF
--- a/lmp/bb-selftest.sh
+++ b/lmp/bb-selftest.sh
@@ -2,6 +2,11 @@
 
 source setup-environment build
 
+# The oe-selftest reproducible is build in two step (A and B) and sharing
+# the same deploy dir will cause some colisions when creating the packages
+# so use the default bitbake settings that is inside the TMP dir
+sed -i -e 's/^DEPLOY_DIR/#&/' conf/site.conf
+
 cat << EOFEOF >> conf/auto.conf
 
 # Disable non compatible classes for oe-selftest

--- a/lmp/bb-selftest.sh
+++ b/lmp/bb-selftest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+source setup-environment build
+
+cat << EOFEOF >> conf/auto.conf
+
+# Disable non compatible classes for oe-selftest
+INHERIT:remove = "buildhistory"
+INHERIT:remove = "rm_work"
+INHERIT:remove = "create-spdx"
+INHERIT:remove = "archiver"
+EOFEOF
+
+# Save the reproducible test results
+export OEQA_DEBUGGING_SAVED_OUTPUT="${archive}/selftest"
+
+oe-selftest $OS_SELFTEST --newbuilddir $PWD

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -62,6 +62,11 @@ touch ${archive}/bitbake_debug.log ${archive}/bitbake_warning.log ${archive}/bit
 touch ${archive}/bitbake_global_env.txt ${archive}/bitbake_image_env.txt && chown builder ${archive}/bitbake_*_env.txt
 touch ${archive}/app-preload.log && chown builder ${archive}/app-preload.log
 touch ${archive}/tuf-root-fetch.log && chown builder ${archive}/tuf-root-fetch.log
+if [ -n "$OS_SELFTEST" ]; then
+	mkdir ${archive}/selftest && chown builder ${archive}/selftest
+	su builder -c $HERE/bb-selftest.sh
+	exit
+fi
 su builder -c $HERE/bb-build.sh
 
 DEPLOY_DIR="$(grep "^DEPLOY_DIR=" ${archive}/bitbake_global_env.txt | cut -d'=' -f2 | tr -d '"')"


### PR DESCRIPTION
The variable OS_SELFTEST will contain the oe-selftest arguments.
When the variable is defined on the factory-config.yml,
the oe-selftest will run with the arguments specified.

```
oe-selftest $OS_SELFTEST --newbuilddir $PWD
```

The results is also stored on the artifact folder
${archive}/selftest for post analysis.

So the following factory configuration will run the LmP reproducible test.

```
lmp:
  params:
    OS_SELFTEST: "--run-tests lmp_reproducible.ReproducibleTests.test_reproducible_builds"
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>