### PR TITLE
Fetch apps unconditionally

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -304,8 +304,13 @@ if __name__ == '__main__':
                 logger.info("Target has no apps, skipping preload")
                 subprog.tick(complete=True)
                 continue
-            image_file_path, release_info = factory_client.get_target_system_image(target, args.out_image_dir, subprog)
 
+            logger.info(f"Getting info about Target's Lmp release...")
+            release_info = factory_client.get_target_release_info(target)
+            if release_info.lmp_version > 0:
+                logger.info(f"Target's LmP version: {release_info.lmp_version}, yocto version: {release_info.yocto_version}")
+
+            image_file_path = factory_client.get_target_system_image(target, args.out_image_dir, subprog)
             apps_dir = None
             if args.app_type == 'restorable' or (not args.app_type and release_info.lmp_version > 84):
                 logger.info('Preloading Restorable Apps...')

--- a/factory_client.py
+++ b/factory_client.py
@@ -145,7 +145,6 @@ class FactoryClient:
         extracted_image_file_path = image_file_path.rstrip('.gz')
 
         p = Progress(2, progress)
-
         if not os.path.exists(extracted_image_file_path):
             logger.info('Downloading Target system image...; Target: {}, image: {}'
                         .format(target.name, image_filename))
@@ -155,13 +154,12 @@ class FactoryClient:
                 for data_chunk in image_resp.iter_content(chunk_size=65536):
                     image_file.write(data_chunk)
             p.tick()
-
             logger.info('Extracting Target system image: {}'.format(image_file_path))
             subprocess.check_call(['gunzip', '-f', image_file_path])
-            p.tick()
         else:
             logger.info('Target system image has been already downloaded: {}'.format(extracted_image_file_path))
 
+        p.tick(complete=True)
         return extracted_image_file_path
 
     def get_target_release_info(self, target: Target):

--- a/helpers.py
+++ b/helpers.py
@@ -198,14 +198,18 @@ class Progress:
         elif self.cur < self.total:
             self.cur += 1
 
-        percent = round(self.cur / self.total * 100)
+        percent = self._get_cur_progress()[0]
         if self.parent:
-            parent_total = round(self.parent.cur / self.parent.total * 100)
-            percent = parent_total + round(percent / self.parent.total)
-
             if self.cur == self.total:
                 self.parent.cur += 1
         self.show_progress(percent)
 
     def show_progress(self, percent_complete: int):
         status('Run is %d%% complete' % percent_complete, prefix='##')
+
+    def _get_cur_progress(self):
+        if self.parent:
+            parent_progress, parent_total = self.parent._get_cur_progress()
+            return parent_progress + round(100 * (self.cur/(self.total * parent_total))), (self.total * parent_total)
+        else:
+            return round(100 * (self.cur / self.total)), self.total


### PR DESCRIPTION
Fetch and store Restorable Apps regardless whether the assemble run succeeds with Apps preloading or not.
Therefore, a user can download an apps tarball for offline update even if app preloading fails, e.g. a WIC image is not supported. 