### PR TITLE
apps: Create a helper for docker-login

### DIFF
--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -42,12 +42,7 @@ if [ -f $pbc ] ; then
   . $pbc
 fi
 
-if [ -f /secrets/container-registries ] ; then
-	PYTHONPATH=$HERE/.. $HERE/login_registries /secrets/container-registries
-fi
-
-status Doing docker-login to hub.foundries.io with secret
-docker login hub.foundries.io --username=doesntmatter --password="$(cat "${SECRETS}/osftok")" | indent
+docker_login
 
 if [ ! -f "${PUBLISH_TOOL}" ]; then
   status Dowloading "compose-ref (aka compose-publish)" for publishing apps

--- a/helpers.sh
+++ b/helpers.sh
@@ -7,6 +7,15 @@ function status { echo == $(date "+%F %T") $* ; }
 
 function run { set -o pipefail; status "Running: $*"; $* 2>&1 | indent ; }
 
+function docker_login {
+	status "Doing docker-login to hub.foundries.io with secret"
+	docker login hub.foundries.io --username=doesntmatter --password=$(cat /secrets/osftok) | indent
+
+	if [ -f /secrets/container-registries ] ; then
+		PYTHONPATH=$HERE/.. $HERE/login_registries /secrets/container-registries
+	fi
+}
+
 function require_params {
 	for x in $* ; do
 		eval val='$'$x


### PR DESCRIPTION
This consolidates the docker-login logic to a single helper.

This also changes the container build process only call docker-login once against hub.fio which is all that's needed. Calling multiple times has no effect. We are also long past the time you could run this script with "noauth", so I simplified the logic