### PR TITLE
Preload to docker unconditionally

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -368,13 +368,9 @@ if __name__ == '__main__':
                 logger.info('Preloading Restorable Apps...')
                 copy_restorable_apps_to_wic(target, image, fetched_apps[target.name][0], preload_progress)
 
-            if target.name not in fetched_apps or target.lmp_version < 87:
-                # Preload compose Apps if restorable one were not preloaded
-                # or LmP version is lower than 87 (no early startup of restorable Apps,
-                # so compose one should be preloaded too to make early startup working)
-                logger.info('Preloading Compose Apps...')
-                copy_compose_apps_to_wic(target, args.fetch_dir + "/compose", image, args.token,
-                                         args.app_shortlist, preload_progress)
+            logger.info('Preloading Compose Apps...')
+            copy_compose_apps_to_wic(target, args.fetch_dir + "/compose", image, args.token,
+                                     args.app_shortlist, preload_progress)
 
             # Don't think its possible to have more than one tag at the time
             # we assemble, but the first tag will be the primary thing its


### PR DESCRIPTION
Preload Apps to the dockerd store unconditionally even if the restorable apps are preloaded to the skopeo/OCI store.    

The reason for doing so is to optimize the timing of the app's "early" startup by eliminating the need to copy the app's data (layers/images) from the skopeo store to the dockerd store during the early startup process.
The copying process can be time-consuming on resource-constrained devices, as it involves untarring and decompression of data.
