### PR TITLE
assemble: Fetch apps to the NFS storage by default

### DIFF
--- a/assemble-system-image.sh
+++ b/assemble-system-image.sh
@@ -20,7 +20,7 @@ OUT_IMAGE_DIR="${OUT_IMAGE_DIR-/archive}"
 APP_SHORTLIST="${APP_SHORTLIST-""}"
 COMPOSE_APP_TYPE=${COMPOSE_APP_TYPE-""}
 # directory to preload/dump/snapshot apps images to
-FETCH_DIR="${FETCH_DIR-$(mktemp -u -d)}"
+FETCH_DIR="${FETCH_DIR-$(mktemp -u -d -p /var/cache/apps)}"
 
 require_params FACTORY OUT_IMAGE_DIR
 if [ -z "${TARGETS}" ] && [ -z "${TARGET_VERSION}" ]; then

--- a/assemble.py
+++ b/assemble.py
@@ -299,6 +299,7 @@ def get_args():
 if __name__ == '__main__':
     exit_code = 0
     fetched_apps = {}
+    fetch_dir = ""
     image = ""
     p = Progress(total=3)  # fetch apps, preload images, move apps to the archive dir
 
@@ -306,6 +307,7 @@ if __name__ == '__main__':
         logging.basicConfig(format='%(asctime)s %(levelname)s: %(module)s: %(message)s', level=logging.INFO)
         args = get_args()
 
+        fetch_dir = args.fetch_dir
         factory_client = FactoryClient(args.factory, args.token)
         if args.targets:
             logger.info('Getting Targets for {}'.format(args.targets))
@@ -390,6 +392,11 @@ if __name__ == '__main__':
     for target, (apps_desc, dst_dir) in fetched_apps.items():
         os.makedirs(dst_dir, exist_ok=True)
         cmd('tar', '-cf', os.path.join(dst_dir, target + '-apps.tar'), '-C', apps_desc.dir, '.')
+
+    # Cleanup the fetched images
+    if os.path.exists(fetch_dir):
+        logger.info(f'Removing `{fetch_dir}` directory Apps were fetched to...')
+        shutil.rmtree(fetch_dir, ignore_errors=True)
 
     p.tick(complete=True)
     exit(exit_code)


### PR DESCRIPTION
Fetch app images to the NFS sub-directory (NFS dir mounted to the container) by default.

Currently, app images are fetched to the container `tmp` dir mapped to a host's RAM. The host's RAM capacity can be lower than the overall size of extracted/pulled App images, hence we need to pull them into some other folder.

Not mapping the container's tmp implies that the tmp is based on the host's overlay2 FS (the CI run container FS); it doesn't work too because of the "overlay2 over overlay2 issue", dockerd cannot have a data root based on overlay2 FS.

Therefore, the only feasible solution left is to fetch app images to the NFS sub-directory which is mapped to a host's directory located on a NFS volume.