### PR TITLE
lmp: Move to "main" OTA tag

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -13,7 +13,7 @@ triggers:
         https://github.com/foundriesio/lmp-manifest.git
       GIT_POLL_REFS: |
         refs/heads/main
-      OTA_LITE_TAG: postmerge
+      OTA_LITE_TAG: main
     runs:
       # images that have ptest
       - name: "{loop}"
@@ -138,7 +138,7 @@ triggers:
         https://github.com/foundriesio/lmp-manifest.git
       GIT_POLL_REFS: |
         refs/heads/main-next
-      OTA_LITE_TAG: 'postmerge-next:postmerge'
+      OTA_LITE_TAG: 'main-next:main'
       AKLITE_TAG: promoted-next
     runs:
       # images that have ptest
@@ -260,7 +260,7 @@ triggers:
         https://github.com/foundriesio/lmp-manifest.git
       GIT_POLL_REFS: |
         refs/heads/kirkstone
-      OTA_LITE_TAG: 'postmerge-stable:postmerge'
+      OTA_LITE_TAG: 'main-stable:main'
       AKLITE_TAG: promoted-stable
     runs:
       - name: "{loop}"
@@ -357,7 +357,7 @@ triggers:
   - name: Code Review
     type: github_pr
     params:
-      OTA_LITE_TAG: 'premerge:postmerge'
+      OTA_LITE_TAG: 'premerge:main'
       AKLITE_TAG: premerge
     runs:
       - name: build-{loop}


### PR DESCRIPTION
Our next release will move users to having an initial factory based on a "fast first target". This target will be the LmP prebuilt release image. These images currently set their default OTA tag as "postmerge". However, the new factories we create for people will be set to "main".

This change makes the tag "main" so that `lmp-device-register` will put the device on the correct initial tag.