### PR TITLE
lmp/bb-config: drop rm_work inherit

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -211,6 +211,10 @@ INHERIT += "archiver"
 COPYLEFT_RECIPE_TYPES = "target"
 ARCHIVER_MODE[src] = "original"
 ARCHIVER_MODE[diff] = "1"
+
+# instead of removing what we no longer need at the end of each bitbake task we
+# can drop everything at the end, the time reduced it's not much but it's about 5 minutes.
+INHERIT:remove = "rm_work"
 EOFEOF
 
 # spdx is support since kirkstone so check if this oe-core have support


### PR DESCRIPTION
If the CI worker have enough space to accommodate everything until the end this can be a good improvement. Instead of removing what we no longer need at the end of each bitbake task we can drop everything at the end, the time reduced it's not much but it's about 5 minutes.