### PR TITLE
lmp/build.sh: create bootchart.svg with the buildstats collected data

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -31,6 +31,12 @@ BUILDSTATS_PATH="$(bitbake-getvar --value TMPDIR | tail -n 1)/buildstats"
 if [ -d $BUILDSTATS_PATH ]; then
     # get the most recent folder
     BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+    # we need to check that because it can't be available in old containers
+    if command -v xvfb-run >/dev/null 2>&1 ; then
+        # producing bootchart.svg
+        run xvfb-run ../layers/openembedded-core/scripts/pybootchartgui/pybootchartgui.py \
+            --minutes --format=svg --output=${archive} $BUILDSTATS_PATH
+    fi
     # write a summary of the buildstats to the terminal
     BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
     # we need to check that because it is only available in the kirkstone branch

--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -26,13 +26,15 @@ if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
 fi
 bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}
 
-# write a summary of the buildstats to the terminal
-BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
-if [ -f $BUILDSTATS_SUMMARY ]; then
-    BUILDSTATS_PATH="$(bitbake-getvar --value TMPDIR | tail -n 1)/buildstats"
-    if [ -d $BUILDSTATS_PATH ]; then
-        # get the most recent folder
-        BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+# Check if the buildstats was enabled
+BUILDSTATS_PATH="$(bitbake-getvar --value TMPDIR | tail -n 1)/buildstats"
+if [ -d $BUILDSTATS_PATH ]; then
+    # get the most recent folder
+    BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+    # write a summary of the buildstats to the terminal
+    BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
+    # we need to check that because it is only available in the kirkstone branch
+    if [ -f $BUILDSTATS_SUMMARY ]; then
         # common arguments with bold disabled
         BUILDSTATS_SUMMARY="$BUILDSTATS_SUMMARY --sort duration --highlight 0"
         # log all task

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -59,6 +59,7 @@ chown -R builder .
 
 su builder -c $HERE/bb-config.sh
 touch ${archive}/customize-target.log && chown builder ${archive}/customize-target.log
+touch ${archive}/bootchart.svg && chown builder ${archive}/bootchart.svg
 touch ${archive}/bitbake_debug.log ${archive}/bitbake_warning.log ${archive}/bitbake_buildstats.log && chown builder ${archive}/bitbake_*.log
 touch ${archive}/bitbake_global_env.txt ${archive}/bitbake_image_env.txt && chown builder ${archive}/bitbake_*_env.txt
 touch ${archive}/app-preload.log && chown builder ${archive}/app-preload.log


### PR DESCRIPTION
In LmP build we have the buildstats enabled because we use the
INHERIT += "buildstats" but the output is hard to read and understand.
The openembedded-core pybootchartgui scripts can process this logs and
generates some pretty charts.