### PR TITLE
lmp/build.sh: create bitbake_buildchart.svg with the buildstats collected data [V2]

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -26,13 +26,19 @@ if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
 fi
 bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}
 
-# write a summary of the buildstats to the terminal
-BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
-if [ -f $BUILDSTATS_SUMMARY ]; then
+# we need to check that because it is not available before kirkstone
+if command -v bitbake-getvar >/dev/null 2>&1; then
+    # get buildstats path
     BUILDSTATS_PATH="$(bitbake-getvar --value TMPDIR | tail -n 1)/buildstats"
-    if [ -d $BUILDSTATS_PATH ]; then
-        # get the most recent folder
-        BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+fi
+# check if the buildstats was enabled
+if [ -d "$BUILDSTATS_PATH" ]; then
+    # get the most recent folder
+    BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+    # write a summary of the buildstats to the terminal
+    BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
+    # we need to check that because it is only available in the kirkstone branch
+    if [ -f $BUILDSTATS_SUMMARY ]; then
         # common arguments with bold disabled
         BUILDSTATS_SUMMARY="$BUILDSTATS_SUMMARY --sort duration --highlight 0"
         # log all task

--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -35,6 +35,12 @@ fi
 if [ -d "$BUILDSTATS_PATH" ]; then
     # get the most recent folder
     BUILDSTATS_PATH="$(ls -td -- $BUILDSTATS_PATH/*/ | head -n 1)"
+    # we need to check that because it can't be available in old containers
+    if command -v xvfb-run >/dev/null 2>&1 ; then
+        # producing bootchart.svg
+        run xvfb-run ../layers/openembedded-core/scripts/pybootchartgui/pybootchartgui.py \
+            --minutes --format=svg --output=${archive}/bitbake_buildchart $BUILDSTATS_PATH
+    fi
     # write a summary of the buildstats to the terminal
     BUILDSTATS_SUMMARY="../layers/openembedded-core/scripts/buildstats-summary"
     # we need to check that because it is only available in the kirkstone branch

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -59,6 +59,7 @@ chown -R builder .
 
 su builder -c $HERE/bb-config.sh
 touch ${archive}/customize-target.log && chown builder ${archive}/customize-target.log
+touch ${archive}/bitbake_buildchart.svg && chown builder ${archive}/bitbake_buildchart.svg
 touch ${archive}/bitbake_debug.log ${archive}/bitbake_warning.log ${archive}/bitbake_buildstats.log && chown builder ${archive}/bitbake_*.log
 touch ${archive}/bitbake_global_env.txt ${archive}/bitbake_image_env.txt && chown builder ${archive}/bitbake_*_env.txt
 touch ${archive}/app-preload.log && chown builder ${archive}/app-preload.log
@@ -134,6 +135,7 @@ if [ -d "${archive}" ] ; then
 	mv ${archive}/bitbake_debug.log.gz ${archive}/other/
 	mv ${archive}/bitbake_warning.log ${archive}/other/
 	mv ${archive}/bitbake_buildstats.log ${archive}/other/
+	mv ${archive}/bitbake_buildchart.svg ${archive}/other/
 
 	# Compress and publish source tarball (for *GPL* packages)
 	if [ -d ${DEPLOY_DIR_IMAGE}/source-release ]; then


### PR DESCRIPTION
First version of this PR https://github.com/foundriesio/ci-scripts/pull/286 have a bug because it uses `bitbake-getvar` and it is not avaliable before `kirstone` and was reverted:

- https://github.com/foundriesio/ci-scripts/commit/7a8772fbf09d9e5759ea9668de979f1ca463b7cb
- https://github.com/foundriesio/ci-scripts/commit/0c25b3ac34b2bb5e9389d0a7629941b2497301e7

The commit https://github.com/foundriesio/ci-scripts/commit/3913debb1bcc0502d49e4d80544ddb67f2dc0352 adress the issue and will checkif `bitbake-getvar` is available.