### PR TITLE
helpers: update repo to v2.35

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -75,7 +75,7 @@ function repo_sync {
 		git config --global http.https://${domain}.extraheader "$(cat /secrets/git.http.extraheader)"
 	fi
 	for i in $(seq 4); do
-		run repo init --repo-rev=v2.29.4 --no-clone-bundle -u $* ${REPO_INIT_OVERRIDES} && break
+		run repo init --repo-rev=v2.35 --no-clone-bundle -u $* ${REPO_INIT_OVERRIDES} && break
 		status "repo init failed with error $?"
 		[ $i -eq 4 ] && exit 1
 		status "sleeping and trying again"


### PR DESCRIPTION
Relevant changes:
- c657844 main: Fix exitcode logging
- 1d3b4fb sync: Track new/existing project count
- be71c2f manifest: enable remove-project using path
- 696e0c4 update links from monorail to issuetracker
- b2263ba sync: Handle case when output isn't connected to a terminal
- 945c006 sync: Update sync progress even when _sync_dict is empty
- 71122f9 sync: Handle race condition when reading active jobs
- 07a4529 pager: set $LESS only when missing
- 1783332 Add envar to replace shallow clones with partial
- 04cba4a sync: Show number of running fetch jobs
- 3eacfdf upload: use f-string
- aafed29 project: Include tags option during fetch retry
- 90f574f Parse OpenSSH versions with no SSH_EXTRAVERSION
- 551285f sync: Show elapsed time for the longest syncing project
- 131fc96 [git_trace2] Add logs for critical cmds
- 2ad5d50 [trace2] Add absolute time on trace2 exit events
- acb9523 SUBMITTING_PATCHES: update with commit queue details
- 041f977 sync: Fix how sync times for shared projects are recorded
- 3e3340d manifest: add support for revision in include
- edcaa94 sync: Display total elapsed fetch time
- 7ef5b46 [SyncAnalysisState] Preserve synctime µs
- e7e20f4 tests: do not allow underscores in cli options
- 99ebf62 upload: Add `--no-follow-tags` by default to git push
- 57cb428 run_tests: Check flake8
- e74d904 Update abandon to support multiple branches
- 21cc3a9 run_tests: Always check black and check it last
- ea2e330 Format codebase with black and check formatting in CQ
- 1604cf2 Make black with line length 80 repo's code style
- 75eb8ea docs: update Focal Python version
- 7fa149b upload: Skip upload if merge branch doesn't match project revision and dest_branch.
- a56e0e1 tests: Change docstring for CopyLinkTestCase
- 3ed8446 tests: Rework run_tests to use pytest directly and add vpython3 file
- 4806771 sync: Remove unused variable
- 69427da Handle KeyboardInterrupt during repo sync
- dccf38e Update sync progress
- 7f44d36 project: clean up error message
- 2aa5d32 Update bug tracking links
- 016a254 git_superproject: Log actual error fmt instead of the entire error message.
- 7eab0ee sync: Silence 'not found in manifest' message
- 7e3b65b Enable use of REPO_CONFIG_DIR to customize .repoconfig location
- c3d61ec init: Silence the "rm -r .repo and try again" message if quiet
- 78e82ec Fix flake8 warnings for some files
- 37ae75f update_manpages.py: treat regex as raw string
- 7438aef Use 'backslashreplace' for decode
- e641281 Use print with flush=True instead of stdout.flush
- 035f22a pylint: remove unused imports
- e0728a5 update-manpages: clean up symlink in checkout
- d98f393 upload: Allow user to configure unusual commit threshold
- 0324e43 repo_trace: Avoid race conditions with trace_file updating.
- 8d25584 github: enable flake8 postsubmit testing
- 0e4f1e7 Use --negotiation-tip in superproject fetches.
- e815286 tests: clean up repo_trace._TRACE_FILE patching
- 0ab6b11 wrapper: switch to functools.lru_cache
- a621254 tests: drop old unittest.main logic
- f159ce0 sync: fix manifest sync-j handling
- 802cd0c sync: Fix undefined variable in _FetchOne
- 100a214 sync: finish marking REPO_AUTO_GC=1 as deprecated.
- 8051cdb test_manifest_config_properties: use assertEqual
- 43549d8 sync: cleanup output when not doing GC
- 55b7125 Revert "sync: save any cruft after calling git gc."
- d793553 sync: mark REPO_AUTO_GC=1 as deprecated.
- ea5239d Fix ManifestProject.partial_clone_exclude property.
- 1b87149 release-process: update to use ./release/sign-tag.py
- 50a2c0e wrapper.py: Replacing load_module() with exec_module()
- 35af2f8 Fixed wrapper related warnings in tests
- e287fa7 test_capture: allow both Unix and Windows line sep
- 3593a10 test_bad_path_name_checks: allow Windows path sep
- 003684b test: Fix char encoding issues on windows
- 0297f83 test: fix path seperator errors on windows
- 7b3afca tox: Allow passing positional arguments
- eda6b1e trace: make test timeout after 2min
- 4364a79 tox: Make all tests timeout after 5min
- a98a5eb Update GH Action test-ci.yml dependencies
- f8d342b tox: enable python 3.10 testing
- 6d2e8c8 Resolved DeprecationWarning for currentThread()
- a24185e Set repo version to 2.30 (current)
- d686365 Extract env building into a testable helper.
- d3cadf1 Do not set ALT object dirs when said path resolves to the same dir.
- fa90f7a tests: Fix update-manpages test.
- bee4efb subcmds: display correct path multitree messages
- f8af33c update-manpages: explicitly strip color codes
- ed25be5 repo_trace: drop notification of trace file name.
- afd7671 repo_trace: adjust formatting, update man page.
- b240d28 upload: track projects by path, rather than name
- 47020ba trace: restore Progress indicator.
- 5ed8c63 sync: REPO_AUTO_GC=1 to restore old behavior.
- 24c6314 Fix TRACE_FILE renaming.
- 7efab53 sync: no garbage collection by default
- a3ff64c Improve always-on-trace
- 776138a Merge branch stable into main (--strategy=ours).
- 5fb9c6a v2.29.7: Revert back to v2.29.5
- 859d3d9 GitcInit: fix gitc-init failure
- fa8d939 sync: clear preciousObjects when set in error.
- a6c52f5 Set tracing to always on and save to .repo/TRACE_FILE.
- 0d130d2 tests: Make the tests pass for Python < 3.8
- b750b48 init: add --manifest-depth for shallow manifest clone
- 6c8b894 Revert "init: change --depth default to 1 for manifest repo"
- b6cfa09 sync: uninitialized variable on mirror sync failure