### PR TITLE
Revert "lmp/bb-build: since lmp v87 the setscene-only is not need any more"

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -15,11 +15,8 @@ bitbake -p
 bitbake -e > ${archive}/bitbake_global_env.txt
 bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
 
-# Before LmP version 87 (first release with OE-core kirkstone),
-# this is need to avoid build failures that can recover in the next steps
-if [ "$LMP_VERSION" -lt "87" ]; then
-    bitbake --setscene-only ${IMAGE} || true
-fi
+# Setscene (cache), failures not critical
+bitbake --setscene-only ${IMAGE} || true
 
 if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
     bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE} -c populate_sdk


### PR DESCRIPTION
This reverts commit 40a0e96a47306e1f8d71722ccd073d6ab3fa751e.

There is still an issue pending that need the build in two steps. We have seen some failed builds with [1] where the bitbake build everything but the build fails at the end.
More investiagation is needed to root cause and fix the issue on the bitbake code base.

[1] `failed with exit code ‘1' - real task will be run instead`

[FFTK-2690]