### PR TITLE
lmp/bb-build: add the time bitbake requires to run

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -9,19 +9,22 @@ start_ssh_agent
 source setup-environment build
 
 # Parsing first, to stop in case of parsing issues
-bitbake -p
+run bitbake -p
 
 # Global and image specific envs
+status "Save the global and image specific environments"
 bitbake -e > ${archive}/bitbake_global_env.txt
 bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
 
 # Setscene (cache), failures not critical
-bitbake --setscene-only ${IMAGE} || true
+set +e
+run bitbake --setscene-only ${IMAGE}
+set -e
 
 if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
-    bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE} -c populate_sdk
+    run bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE} -c populate_sdk
 fi
-bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}
+run bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}
 
 # we need to check that because it is not available before kirkstone
 if command -v bitbake-getvar >/dev/null 2>&1; then


### PR DESCRIPTION
```
== 2023-08-08 11:10:06 Running: bitbake -p
|  Loading cache...done.
|  Loaded 0 entries from dependency cache.
|  Parsing recipes...done.
|  Parsing of 7680 .bb files complete (0 cached, 7680 parsed). 11906 targets, 2150 skipped, 20 masked, 0 errors.
|--
== 2023-08-08 11:13:12 get global and image specific environments
== 2023-08-08 11:14:57 Running: bitbake --setscene-only lmp-base-console-image
| Loading cache...done.
| Loaded 11906 entries from dependency cache.
| ...
|--
== 2023-08-08 11:19:24 Running: bitbake -D lmp-base-console-image
| Loading cache...done.
| Loaded 11906 entries from dependency cache.
| ...
|--
```