### PR TITLE
Generate and upload delta stats

### DIFF
--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -51,8 +51,8 @@ def drain(progress: Progress, response, prog_cb: ProgressCb, dst: str):
 
 
 def _download_extract(progress: Progress, tarurls: List[str], dst: str):
-    status(f"Downloading: {tarurls} -> {dst}ostree_repo")
-
+    status("Downloading the following {} ostree repos into the single one -> {}ostree_repo\n\t{}"
+           .format(len(tarurls), dst, "\n\t".join(tarurls)))
     total_length = 0
     responses = []
     for u in tarurls:

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 import requests
 from shutil import rmtree
 from subprocess import Popen, PIPE
-from typing import List, Tuple
+from typing import List
 
 from helpers import (
     Progress,
@@ -19,7 +19,7 @@ from helpers import (
     require_env,
     require_secrets,
     secret,
-    secret_get,
+    http_get,
     status,
 )
 from static_deltas import Delta, generate_deltas
@@ -39,33 +39,39 @@ class ProgressCb:
             self.next_percent += 5
 
 
-def drain(progress: Progress, response, prog_cb: ProgressCb, dst: str):
+def drain(progress: Progress, u, prog_cb: ProgressCb, dst: str, tok_secret_name: str):
+    r = http_get(u, headers={
+        "OSF-TOKEN": secret(tok_secret_name),
+        "Connection": "keep-alive",
+        "Keep-Alive": "timeout=1200, max=1"  # keep connection alive for 1 request for 20m
+    }, stream=True)
     p = Popen(["tar", "-xj"], cwd=dst, stdin=PIPE)
-    for chunk in response.iter_content(chunk_size=1024 * 1024):
+    for chunk in r.iter_content(chunk_size=1024 * 1024):
         if chunk:
             p.stdin.write(chunk)
             prog_cb(len(chunk))
     p.stdin.close()
     p.wait()
+    status(f"Downloaded and extracted: {u}")
     progress.tick()
 
 
-def _download_extract(progress: Progress, tarurls: set[str], dst: str):
+def _download_extract(progress: Progress, tarurls: set[str], dst: str, tok_secret_name: str):
     status("Downloading the following {} ostree repos into the single one -> {}ostree_repo\n\t{}"
            .format(len(tarurls), dst, "\n\t".join(tarurls)))
     total_length = 0
-    responses = []
     for u in tarurls:
-        r = secret_get(u, "osftok", "OSF-TOKEN", stream=True)
+        r = requests.head(u, headers={"OSF-TOKEN": secret(tok_secret_name)}, allow_redirects=True)
+        if r.status_code != 200:
+            sys.exit('Unable to find %s: %d\n%s' % (u, r.status_code, r.text))
         total_length += int(r.headers["content-length"])
-        responses.append(r)
 
     cb = ProgressCb(total_length)
 
     with ThreadPoolExecutor(max_workers=3) as executor:
         futures = []
-        for r in responses:
-            futures.append(executor.submit(drain, progress, r, cb.cb, dst))
+        for u in tarurls:
+            futures.append(executor.submit(drain, progress, u, cb.cb, dst, tok_secret_name))
         for f in futures:
             f.result()
 
@@ -122,7 +128,7 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
 
     prog = Progress(work)
     if len(downloads) > 0:
-        _download_extract(prog, downloads, "./")
+        _download_extract(prog, downloads, "./", tok_secret_name)
 
     if len(pulls) > 0:
         status(f"Pulling: {pulls} -> ./ostree_repo")

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -27,7 +27,8 @@ from static_deltas import (
     Delta,
     generate_deltas,
     save_delta_stats,
-    upload_delta_stats
+    upload_delta_stats,
+    add_delta_stat_refs_to_targets
 )
 
 
@@ -169,6 +170,10 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
     prog.tick()
 
     upload_delta_stats(factory, delta_stats, tok_secret_name)
+    prog.tick()
+
+    status("Updating Factory's TUF Targets with references to delta statistics...")
+    add_delta_stat_refs_to_targets(creds_zip_file, delta_stats)
     prog.tick()
 
 

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -26,7 +26,8 @@ from helpers import (
 from static_deltas import (
     Delta,
     generate_deltas,
-    save_delta_stats
+    save_delta_stats,
+    upload_delta_stats
 )
 
 
@@ -114,7 +115,7 @@ def pull_ostree_commit(factory: str, commit_hash: str, ostree_repo_dir: str, tok
 def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name: str, out_dir: str):
     load_extra_certs()
 
-    work = 2  # 1 for the fiopush + 1 for saving delta stats files
+    work = 3  # 1 for the fiopush + 2 for saving and uploading delta stats files
     downloads = set()  # a set of URLs to ostree repo archives to download from Jobserv
     pulls = set()  # a set of ostree commit hashes to pull from ostreehub (if no URL to archive)
     for d in deltas:
@@ -165,6 +166,9 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
 
     status(f"Saving delta statistics files to {out_dir}...")
     save_delta_stats(delta_stats, out_dir)
+    prog.tick()
+
+    upload_delta_stats(factory, delta_stats, tok_secret_name)
     prog.tick()
 
 

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -2,12 +2,13 @@
 from concurrent.futures import ThreadPoolExecutor
 import json
 import os
+import io
 import pty
 import sys
 from tempfile import mkstemp
 import requests
+import tarfile
 from shutil import rmtree
-from subprocess import Popen, PIPE
 from typing import List
 
 from helpers import (
@@ -39,19 +40,19 @@ class ProgressCb:
             self.next_percent += 5
 
 
-def drain(progress: Progress, u, prog_cb: ProgressCb, dst: str, tok_secret_name: str):
+def drain(progress: Progress, u, prog_cb: ProgressCb.cb, dst: str, tok_secret_name: str):
     r = http_get(u, headers={
         "OSF-TOKEN": secret(tok_secret_name),
         "Connection": "keep-alive",
         "Keep-Alive": "timeout=1200, max=1"  # keep connection alive for 1 request for 20m
     }, stream=True)
-    p = Popen(["tar", "-xj"], cwd=dst, stdin=PIPE)
-    for chunk in r.iter_content(chunk_size=1024 * 1024):
-        if chunk:
-            p.stdin.write(chunk)
-            prog_cb(len(chunk))
-    p.stdin.close()
-    p.wait()
+    last_pos = 0
+    with io.BufferedReader(r.raw, buffer_size=1024 * 1024) as br:
+        with tarfile.open(fileobj=br, mode="r|bz2") as tar_stream:
+            for member in tar_stream:
+                tar_stream.extract(member, dst)
+                prog_cb(br.tell() - last_pos)
+                last_pos = br.tell()
     status(f"Downloaded and extracted: {u}")
     progress.tick()
 
@@ -68,7 +69,7 @@ def _download_extract(progress: Progress, tarurls: set[str], dst: str, tok_secre
 
     cb = ProgressCb(total_length)
 
-    with ThreadPoolExecutor(max_workers=3) as executor:
+    with ThreadPoolExecutor(max_workers=10) as executor:
         futures = []
         for u in tarurls:
             futures.append(executor.submit(drain, progress, u, cb.cb, dst, tok_secret_name))

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -23,7 +23,11 @@ from helpers import (
     http_get,
     status,
 )
-from static_deltas import Delta, generate_deltas
+from static_deltas import (
+    Delta,
+    generate_deltas,
+    save_delta_stats
+)
 
 
 class ProgressCb:
@@ -107,10 +111,10 @@ def pull_ostree_commit(factory: str, commit_hash: str, ostree_repo_dir: str, tok
               read_progress)
 
 
-def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name: str):
+def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name: str, out_dir: str):
     load_extra_certs()
 
-    work = 1  # 1 for the fiopush
+    work = 2  # 1 for the fiopush + 1 for saving delta stats files
     downloads = set()  # a set of URLs to ostree repo archives to download from Jobserv
     pulls = set()  # a set of ostree commit hashes to pull from ostreehub (if no URL to archive)
     for d in deltas:
@@ -135,8 +139,9 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
         status(f"Pulling: {pulls} -> ./ostree_repo")
         for commit in pulls:
             pull_ostree_commit(factory, commit, "./ostree_repo", tok_secret_name, ostree_url)
+            prog.tick()
 
-    generate_deltas(prog, deltas, "./ostree_repo")
+    delta_stats = generate_deltas(prog, deltas, "./ostree_repo")
 
     # update summary and generate a new type of delta indexes
     cmd("ostree", "summary", "-u", "--repo=./ostree_repo")
@@ -158,6 +163,10 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
     cmd("fiopush", "-summary", "-repo=./ostree_repo", "-creds", creds_zip_file)
     prog.tick()
 
+    status(f"Saving delta statistics files to {out_dir}...")
+    save_delta_stats(delta_stats, out_dir)
+    prog.tick()
+
 
 if __name__ == "__main__":
     require_env("FACTORY")
@@ -172,4 +181,4 @@ if __name__ == "__main__":
     factory = os.environ["FACTORY"]
     repo_parent = os.environ.get("OSTREE_REPO_ROOT", "/")
     os.chdir(repo_parent)
-    main(creds_tmp, deltas, factory, "osftok")
+    main(creds_tmp, deltas, factory, "osftok", os.environ.get("ARCHIVE", "/archive"))

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 import requests
 from shutil import rmtree
 from subprocess import Popen, PIPE
-from typing import List, NamedTuple, Tuple
+from typing import List
 
 from helpers import (
     Progress,
@@ -22,11 +22,7 @@ from helpers import (
     secret_get,
     status,
 )
-
-
-class Delta(NamedTuple):
-    to: Tuple[str, str]
-    froms: List[Tuple[str, str]]
+from static_deltas import Delta, generate_deltas
 
 
 class ProgressCb:
@@ -133,12 +129,7 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
         for commit in pulls:
             pull_ostree_commit(factory, commit, "./ostree_repo", tok_secret_name, ostree_url)
 
-    for d in deltas:
-        for f in d.froms:
-            sha, _ = f
-            status("Generating delta", with_ts=True)
-            cmd("ostree", "static-delta", "generate", "--repo=./ostree_repo", "--from", sha, "--to", d.to[0])
-            prog.tick()
+    generate_deltas(prog, deltas, "./ostree_repo")
 
     # update summary and generate a new type of delta indexes
     cmd("ostree", "summary", "-u", "--repo=./ostree_repo")

--- a/lmp/generate-static-deltas
+++ b/lmp/generate-static-deltas
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 import requests
 from shutil import rmtree
 from subprocess import Popen, PIPE
-from typing import List
+from typing import List, Tuple
 
 from helpers import (
     Progress,
@@ -50,7 +50,7 @@ def drain(progress: Progress, response, prog_cb: ProgressCb, dst: str):
     progress.tick()
 
 
-def _download_extract(progress: Progress, tarurls: List[str], dst: str):
+def _download_extract(progress: Progress, tarurls: set[str], dst: str):
     status("Downloading the following {} ostree repos into the single one -> {}ostree_repo\n\t{}"
            .format(len(tarurls), dst, "\n\t".join(tarurls)))
     total_length = 0
@@ -104,18 +104,18 @@ def main(creds_zip_file: str, deltas: List[Delta], factory: str, tok_secret_name
     load_extra_certs()
 
     work = 1  # 1 for the fiopush
-    downloads = []
-    pulls = []
+    downloads = set()  # a set of URLs to ostree repo archives to download from Jobserv
+    pulls = set()  # a set of ostree commit hashes to pull from ostreehub (if no URL to archive)
     for d in deltas:
-        downloads.append(d.to[1]) if d.to[1] else pulls.append(d.to[0])
-        work += 1
+        (e, s) = (d.to[1], downloads) if d.to[1] else (d.to[0], pulls)
+        if e not in s:
+            work += 1
+            s.add(e)
         for x in d.froms:
-            if x[1]:
-                downloads.append(x[1])
-            else:
-                pulls.append(x[0])
-            # 2 for the "from":  download | pull, and generate delta
-            work += 2
+            (e, s) = (x[1], downloads) if x[1] else (x[0], pulls)
+            if e not in s:
+                work += 2  # 2 for the "from":  download | pull, and generate delta
+                s.add(e)
 
     base = fio_dnsbase()
     ostree_url = f"https://api.{base}/ota/ostreehub"

--- a/lmp/static_deltas.py
+++ b/lmp/static_deltas.py
@@ -1,0 +1,20 @@
+from typing import List, NamedTuple, Tuple
+
+from helpers import (
+    Progress,
+    status,
+    cmd
+)
+
+
+class Delta(NamedTuple):
+    to: Tuple[str, str]
+    froms: List[Tuple[str, str]]
+
+
+def generate_deltas(prog: Progress, deltas: List[Delta], repo: str):
+    for delta in deltas:
+        for from_sha, _ in delta.froms:
+            cmd("ostree", "static-delta",
+                "generate", f"--repo={repo}", "--from", from_sha, "--to", delta.to[0])
+            prog.tick()

--- a/lmp/static_deltas.py
+++ b/lmp/static_deltas.py
@@ -1,20 +1,70 @@
+import os
+import hashlib
+import canonicaljson
 from typing import List, NamedTuple, Tuple
 
 from helpers import (
     Progress,
-    status,
     cmd
 )
 
 
 class Delta(NamedTuple):
-    to: Tuple[str, str]
+    to: Tuple[str, str]  # (hash, uri)
     froms: List[Tuple[str, str]]
 
 
-def generate_deltas(prog: Progress, deltas: List[Delta], repo: str):
-    for delta in deltas:
-        for from_sha, _ in delta.froms:
+def generate_deltas(prog: Progress, deltas: List[Delta], repo: str) -> dict:
+    delta_stats = {}
+    for (to_sha, _), from_list in deltas:
+        delta_stat = {to_sha: {}}  # delta stats for a single `to` and many `from`
+        for from_sha, _ in from_list:
             cmd("ostree", "static-delta",
-                "generate", f"--repo={repo}", "--from", from_sha, "--to", delta.to[0])
+                "generate", f"--repo={repo}", "--from", from_sha, "--to", to_sha)
+
+            # Get delta stats for the given `from`
+            delta_stat[to_sha][from_sha] = _get_delta_stats(repo, from_sha, to_sha)
             prog.tick()
+
+        delta_stat_json = canonicaljson.encode_canonical_json(delta_stat)
+        delta_stat_json_sha = hashlib.sha256()
+        delta_stat_json_sha.update(delta_stat_json)
+        delta_stats[to_sha] = {
+            "sha256": delta_stat_json_sha.hexdigest(),
+            "canonical-json": delta_stat_json
+        }
+    return delta_stats
+
+
+# The delta stats are saved as a canonical json; a file name matches a `to` hash. Format is:
+# {
+#   "to-hash": {
+#       "from-hash": { "size": <compressed delta size>, "u_size": <unpacked delta size>}
+#       ...
+#    }
+# }
+def save_delta_stats(delta_stats: dict, out_dir: str):
+    for to_sha, s in delta_stats.items():
+        with open(os.path.join(out_dir, f"{to_sha}.json"), "wb") as f:
+            f.write(s["canonical-json"])
+
+
+def _get_delta_stats(repo: str, from_sha: str, to_sha: str) -> dict:
+    stat_out = cmd("ostree", "static-delta",
+                   "show", f"--repo={repo}", f"{from_sha}-{to_sha}", capture=True)
+    stat_out_lines = stat_out.splitlines()
+    # parse output of the `ostree static-delta show` command
+    stats = {}
+    indx = 0
+    for s in [("Total Uncompressed Size:", "u_size"), ("Total Size:", "size")]:
+        stat_line = stat_out_lines[len(stat_out_lines) - 1 - indx].decode()
+        if not stat_line.startswith(s[0]):
+            raise Exception("Invalid static delta statistic output;"
+                            f" expected {s[0]}, got {stat_line}")
+        end_pos = stat_line[len(s[0]):].find("(")
+        if -1 == end_pos:
+            raise Exception("Invalid static delta statistic output;"
+                            f" expected to find `(<value>)`, got {stat_line}")
+        stats[s[1]] = int(stat_line[len(s[0]):len(s[0]) + end_pos].strip())
+        indx += 1
+    return stats

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 requests-mock==1.8.0
 PyYAML==6.0.1
 expandvars==0.6.5
+canonicaljson==2.0.0

--- a/tests/test_deltas_generation.py
+++ b/tests/test_deltas_generation.py
@@ -19,12 +19,13 @@
 #
 # <ostree-repo> - a repo that contains all commits referenced in <deltas-file>
 
+import os
 import argparse
 import json
 
 from typing import List
 
-from lmp.static_deltas import Delta, generate_deltas
+from lmp.static_deltas import Delta, generate_deltas, save_delta_stats
 from helpers import Progress
 
 
@@ -33,6 +34,8 @@ def get_args():
     parser.add_argument("-f", "--deltas", help="File with ostree hashes to generate delta for")
     parser.add_argument("-t", "--repo", help="Path to an ostree repo that contains commits"
                                              " to generate delta for")
+    parser.add_argument('-o', '--output-dir',
+                        help='Path to a dir to store generated delta stat files')
     return parser.parse_args()
 
 
@@ -49,4 +52,6 @@ if __name__ == "__main__":
         work += len(d.froms)
 
     prog = Progress(work)
-    generate_deltas(prog, deltas, args.repo)
+    delta_stats = generate_deltas(prog, deltas, args.repo)
+    save_delta_stats(delta_stats, args.output_dir)
+

--- a/tests/test_deltas_generation.py
+++ b/tests/test_deltas_generation.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+# Example: PYTHONPATH=./ ./tests/test_deltas_generation.py --deltas <deltas-file> --repo <ostree-repo>
+# <deltas-file> - a file containing json with ostree commit hashes to create delta:
+# [
+# 	{
+# 		"to": [
+# 			"210da9e7a5330473b12a9a2ff9e08fccd8f6f14453e13e0c2c7a5bb7e0f11d05",
+# 			"https://api.foundries.io/projects/<factory>/lmp/builds/2051/runs/intel-corei7-64/other/intel-corei7-64-ostree_repo.tar.bz2"
+# 			],
+# 		"froms": [
+# 			[
+# 				"ed7ec4eb077f1365ff5b800fa89bc5ec93cba88ceda96d6f87970932ff0bf4b5",
+# 				"https://api.foundries.io/projects/<factory>/lmp/builds/2050/runs/intel-corei7-64/other/intel-corei7-64-ostree_repo.tar.bz2"
+# 			]
+# 		]
+# 	}
+# ]
+#
+# <ostree-repo> - a repo that contains all commits referenced in <deltas-file>
+
+import argparse
+import json
+
+from typing import List
+
+from lmp.static_deltas import Delta, generate_deltas
+from helpers import Progress
+
+
+def get_args():
+    parser = argparse.ArgumentParser('''Generate static deltas''')
+    parser.add_argument("-f", "--deltas", help="File with ostree hashes to generate delta for")
+    parser.add_argument("-t", "--repo", help="Path to an ostree repo that contains commits"
+                                             " to generate delta for")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+    deltas: List[Delta] = []
+    with open(args.deltas) as f:
+        deltas_json = json.load(f)
+        for dj in deltas_json:
+            deltas.append(Delta(**dj))
+
+    work = 0
+    for d in deltas:
+        work += len(d.froms)
+
+    prog = Progress(work)
+    generate_deltas(prog, deltas, args.repo)

--- a/tests/test_static_deltas_generation.sh
+++ b/tests/test_static_deltas_generation.sh
@@ -24,6 +24,8 @@ H_BUILD=$5
 
 WORK_DIR=${6-"$(mktemp -d -t generate-static-deltas-XXXXXXXXXX)"}
 echo ">> Work dir: ${WORK_DIR}"
+ARCHIVE="${WORK_DIR}/archive"
+mkdir -p "${ARCHIVE}"
 
 echo -n "${OSF_TOKEN}" > "${SECRETS_DIR}/osftok"
 echo -n "${USER_ID}" > "${SECRETS_DIR}/triggered-by"
@@ -39,5 +41,6 @@ docker run -v -it --rm \
   -e H_BUILD="${H_BUILD}" \
   -v $PWD:/ci-scripts \
   -v $SECRETS_DIR:/secrets \
+  -v $ARCHIVE:/archive \
   -w /ci-scripts \
   foundries/lmp-image-tools "${CMD}"

--- a/tests/test_static_deltas_generation.sh
+++ b/tests/test_static_deltas_generation.sh
@@ -1,0 +1,43 @@
+# example: ./tests/test_static_deltas_generation.sh $FACTORY $USER_TOKEN $USER_ID $SECRETS_DIR $BUILD_NUMB $WORK_DIR
+# Input params
+FACTORY=$1
+OSF_TOKEN=$2
+# USER_ID = $(fioctl users -f <factory>)
+USER_ID=$3
+# must have `deltas` file that contains `to` and `froms` dicts, e.g.
+#[
+# {
+#		"to": [
+#			"8746add97a01d76cec838f29ab9782fd5ba2a85099eb4569d5ae5b52275f4985",
+#			"https://api.foundries.io/projects/msul-dev01/lmp/builds/2071/runs/intel-corei7-64/other/intel-corei7-64-ostree_repo.tar.bz2"
+#			],
+#		"froms": [
+#			[
+#				"bc0d3ff32fe90e03f1d572900f6c5d9f40d3173c00910f09c899b4a284e09322",
+#				"https://api.foundries.io/projects/msul-dev01/lmp/builds/2070/runs/intel-corei7-64/other/intel-corei7-64-ostree_repo.tar.bz2"
+#			],
+#		]
+#  }
+#]
+SECRETS_DIR=$4
+H_BUILD=$5
+
+WORK_DIR=${6-"$(mktemp -d -t generate-static-deltas-XXXXXXXXXX)"}
+echo ">> Work dir: ${WORK_DIR}"
+
+echo -n "${OSF_TOKEN}" > "${SECRETS_DIR}/osftok"
+echo -n "${USER_ID}" > "${SECRETS_DIR}/triggered-by"
+
+CMD=./lmp/generate-static-deltas
+H_RUN_URL="https://api.foundries.io/projects/{FACTORY}/lmp/builds/${H_BUILD}/runs/generate/"
+
+docker run -v -it --rm \
+  -e FACTORY=$FACTORY \
+  -e PYTHONPATH=./ \
+  -e H_PROJECT="${FACTORY}/lmp" \
+  -e H_RUN_URL="${H_RUN_URL}" \
+  -e H_BUILD="${H_BUILD}" \
+  -v $PWD:/ci-scripts \
+  -v $SECRETS_DIR:/secrets \
+  -w /ci-scripts \
+  foundries/lmp-image-tools "${CMD}"


### PR DESCRIPTION
- Some refactoring and fixes required by the new functionality.
- Obtain and upload statistics about generated static deltas.
- Update each relevant Target with a reference to the generated and uploaded delta statistic file.