### PR TITLE
lmp: factory-containers: Deprecate ENABLE_PTEST

### DIFF
--- a/factory-containers/jobserv.yml
+++ b/factory-containers/jobserv.yml
@@ -14,7 +14,7 @@ triggers:
       GIT_URL: |
         https://github.com/foundriesio/containers.git
       GIT_POLL_REFS: "refs/heads/master"
-      OTA_LITE_TAG: postmerge,postmerge-ptest
+      OTA_LITE_TAG: postmerge
       DOCKER_COMPOSE_APP: "1"
     runs:
       - name: build-{loop}
@@ -40,7 +40,7 @@ triggers:
         params:
           DOCKER_COMPOSE_APP: "1"
           MANIFEST_PLATFORMS_DEFAULT: linux/amd64,linux/arm64,linux/arm
-          OTA_LITE_TAG: postmerge,postmerge-ptest
+          OTA_LITE_TAG: postmerge
         script-repo:
           name: fio
           path: factory-containers/publish-containers.sh
@@ -57,7 +57,7 @@ triggers:
         params:
           DOCKER_COMPOSE_APP: "1"
           MANIFEST_PLATFORMS_DEFAULT: linux/amd64,linux/arm64,linux/arm
-          OTA_LITE_TAG: premerge:postmerge,premerge-ptest:postmerge-ptest
+          OTA_LITE_TAG: premerge:postmerge
         script-repo:
           name: fio
           path: factory-containers/publish-containers.sh
@@ -71,7 +71,7 @@ triggers:
         container: foundries/dind-ci:19.03.9_057dbdd
         privileged: true
         params:
-          OTA_LITE_TAG: premerge:postmerge,premerge-ptest:postmerge-ptest
+          OTA_LITE_TAG: premerge:postmerge
           DOCKER_COMPOSE_APP: "1"
         loop-on:
           - param: host-tag

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -15,7 +15,6 @@ LMP_OAUTH_API="${LMP_OAUTH_API-https://app.${dns_base}/oauth}"
 FIO_HUB_URL="${FIO_HUB_URL-${hub_fio}}"
 UBOOT_SIGN_ENABLE="${UBOOT_SIGN_ENABLE-0}"
 DISABLE_GPLV3="${DISABLE_GPLV3-0}"
-ENABLE_PTEST="${ENABLE_PTEST-0}"
 DOCKER_MAX_CONCURRENT_DOWNLOADS="${DOCKER_MAX_CONCURRENT_DOWNLOADS-3}"
 DOCKER_MAX_DOWNLOAD_ATTEMPTS="${DOCKER_MAX_DOWNLOAD_ATTEMPTS-5}"
 MFGTOOL_FLASH_IMAGE="${MFGTOOL_FLASH_IMAGE-lmp-factory-image}"
@@ -33,10 +32,6 @@ BUILD_SDK="${BUILD_SDK-0}"
 
 GARAGE_CUSTOMIZE_TARGET_PARAMS='${MACHINE} ${IMAGE_BASENAME} ${TARGET_ARCH} ${DISTRO_VERSION}'
 TUF_TARGETS_EXPIRE="${TUF_TARGETS_EXPIRE-1Y}"
-
-if [ "$ENABLE_PTEST" = "1" ] ; then
-    OSTREE_BRANCHNAME="${OSTREE_BRANCHNAME}-ptest"
-fi
 
 if [ -f "/secrets/targets.sec" ] ; then
 	status "Generating credentials.zip"
@@ -165,30 +160,6 @@ EOFEOF
 IMAGE_INSTALL:append = " ${EXTRA_IMAGE_INSTALL}"
 EOFEOF
 	fi
-fi
-
-# Ptest-based builds require the same build settings and variables,
-# but the final image needs to be tagged differently, such as
-# <main tag>-ptest, so perform the change at the OTA_LITE_TAG variable
-if [ "${ENABLE_PTEST}" = "1" ]; then
-	IFS=","
-	PTAGS=""
-	for tag in ${OTA_LITE_TAG}; do
-		lmptag=$(echo $tag | cut -d: -f1)
-		PTAGS="${PTAGS} ${lmptag}-ptest"
-		contag=$(echo $tag | cut -s -d: -f1 --complement)
-		if [ -n "${contag}" ]; then
-			PTAGS="${PTAGS}:${contag}"
-		fi
-	done
-	unset IFS
-	OTA_LITE_TAG=$(echo ${PTAGS} | sed -e "s/ /,/g")
-	status "PTEST enabled, OTA_LITE_TAG updated to: ${OTA_LITE_TAG}"
-
-	# Install ptest related packages via extra image features
-	cat << EOFEOF >> conf/local.conf
-EXTRA_IMAGE_FEATURES += " ptest-pkgs"
-EOFEOF
 fi
 
 cat << EOFEOF >> conf/local.conf

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -145,10 +145,6 @@ if [ -d "${archive}" ] ; then
 
 	# Compress and publish the ostree repository
 	if [ -d ${DEPLOY_DIR_IMAGE}/ostree_repo ]; then
-		# Update branchname in case ptest is enabled as done by bb-config.sh
-		if [ "$ENABLE_PTEST" = "1" ] ; then
-			OSTREE_BRANCHNAME="${OSTREE_BRANCHNAME}-ptest"
-		fi
 		cat ${DEPLOY_DIR_IMAGE}/ostree_repo/refs/heads/${MACHINE}-${OSTREE_BRANCHNAME} > ${archive}/other/ostree.sha.txt
 		tar --remove-files -C ${DEPLOY_DIR_IMAGE} -cjf ${MACHINE}-ostree_repo.tar.bz2 ostree_repo
 		mv ${MACHINE}-ostree_repo.tar.bz2 ${archive}/other/


### PR DESCRIPTION
Deprecate the variabel ENABLE_PTEST as ptest is disabled by default since [1]

[1] https://github.com/foundriesio/meta-lmp/commit/2e51562a43522cdce418bba0784cc6dfa91d1d61