### PR TITLE
lmp/build: adapt post-build processing to scarthgap

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -129,13 +129,12 @@ if [ -d ${DEPLOY_DIR}/sources ]; then
 			grep -q "NAME: ${p}$" ${DEPLOY_DIR_IMAGE}/*.manifest || continue
 
 			# Only archive GPL packages (update *GPL* regex for additional licenses)
-			numfiles=`ls ${DEPLOY_DIR}/licenses/${p}/*GPL* 2> /dev/null | wc -l`
-			if [ ${numfiles} -gt 0 ]; then
-				mkdir -p ${DEPLOY_SOURCES}/${p}/source
-				cp -f ${pkg}/* ${DEPLOY_SOURCES}/${p}/source 2> /dev/null
-				mkdir -p ${DEPLOY_SOURCES}/${p}/license
-				cp -f ${DEPLOY_DIR}/licenses/${p}/* ${DEPLOY_SOURCES}/${p}/license 2> /dev/null
-			fi
+			find ${DEPLOY_DIR}/licenses -name "*GPL*" -type f 2> /dev/null || continue
+			mkdir -p ${DEPLOY_SOURCES}/${p}/source
+			cp -f ${pkg}/* ${DEPLOY_SOURCES}/${p}/source 2> /dev/null
+			mkdir -p ${DEPLOY_SOURCES}/${p}/license
+			license=`find ${DEPLOY_DIR}/licenses -name "${p}" -type d`
+			cp -f ${license}/* ${DEPLOY_SOURCES}/${p}/license 2> /dev/null
 		done
 	done
 fi

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -81,8 +81,11 @@ rm -f ${DEPLOY_DIR_IMAGE}/*.txt
 ## Only publish wic.gz
 rm -f ${DEPLOY_DIR_IMAGE}/*.wic
 
+set -x
+
 # Link the license manifest for all the images produced by the build
 for img in ${DEPLOY_DIR_IMAGE}/*${MACHINE}*.manifest; do
+	status "Post-build processing (license)"
 	if [ "${DISTRO}" = "lmp-mfgtool" ]; then
 		status "Image manifest not exist in this distro, skipping"
 		break
@@ -117,6 +120,7 @@ done
 # Generate a tarball containing the source code of *GPL* packages (based on yocto dev-manual)
 DEPLOY_SOURCES="${DEPLOY_DIR_IMAGE}/source-release"
 if [ -d ${DEPLOY_DIR}/sources ]; then
+	status "Post-build processing (source release)"
 	mkdir -p ${DEPLOY_SOURCES}
 	for sarch in ${DEPLOY_DIR}/sources/*; do
 		for pkg in ${sarch}/*; do
@@ -140,6 +144,7 @@ if [ -d ${DEPLOY_DIR}/sources ]; then
 fi
 
 if [ -d "${archive}" ] ; then
+	status "Post-build processing (archive)"
 	mkdir ${archive}/other
 	mkdir ${archive}/sdk
 

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -103,7 +103,9 @@ for img in ${DEPLOY_DIR_IMAGE}/*${MACHINE}*.manifest; do
 		ln -sf ${image_name_id}.license.manifest ${DEPLOY_DIR_IMAGE}/${image_name}.license.manifest
 	else
 		status "Image ${image_name} license manifest not found on ${DEPLOY_DIR}/licenses, license manifest can't be collected"
-		eixt 1
+		# FIXME: there is a bug in oe-core and sometimes the lic folder is empty
+		# https://bugzilla.yoctoproject.org/show_bug.cgi?id=15394
+		#eixt 1
 	fi
 	# Also take care of the image_license, which contains the binaries used by wic outside the rootfs
 	if [ -f ${image_path}/image_license.manifest ]; then


### PR DESCRIPTION
**lmp/build: check availability of the image manifest**
- Skip the loop if the disto image manifest not exist
- Fail if the manifest file pattern not exist
- Consider only the symbolic links of the images manifest
- From the licenses deploy dir of the image:
   - Copy the license.manifest, if not possible fail
   - Copy the image_license.manifest
```

| + for img in ${DEPLOY_DIR_IMAGE}/*${MACHINE}.manifest
| ++ basename '/srv/oe/build/deploy/images/intel-corei7-64/*intel-corei7-64.manifest'
| ++ sed -e s/.manifest//
| + image_name='*intel-corei7-64'
| ++ readlink '/srv/oe/build/deploy/images/intel-corei7-64/*intel-corei7-64.manifest'
| ++ sed -e 's/\..*manifest//'
| + image_name_id=
| Script completed with error(s)
```

-----

**lmp/build: don't fail when the license.manifest not found**
There is a bug in oe-core and sometimes the lic folder is empty.
https://bugzilla.yoctoproject.org/show_bug.cgi?id=15394

The intention of this change is to document and be reverted once
the problem is fixed.

