### PR TITLE
Fetch full app tree

### DIFF
--- a/apps/target_apps_fetcher.py
+++ b/apps/target_apps_fetcher.py
@@ -190,3 +190,11 @@ class SkopeAppFetcher(TargetAppsFetcher):
         subprocess.check_call(['skopeo', '--insecure-policy', '--override-arch', arch, 'copy', '--format',
                                'v2s2', '--dest-shared-blob-dir', self.blobs_dir(target_name), 'docker://' + image,
                                'oci:' + image_dir])
+
+        # Store the image manifest in the blob directory, as result it contains all blobs/nodes of
+        # the app's merkle tree. It allows to check app integrity on devices with preloaded apps and
+        # in the case of offline update.
+        # Note: the skopeo is supposed to store it, no idea why they don't do it
+        blob = subprocess.check_output(['skopeo', 'inspect', '--raw', f'docker://{image}'])
+        with open(os.path.join(self.blobs_dir(target_name), "sha256", uri.hash), 'wb') as f:
+            f.write(blob)

--- a/apps/target_apps_fetcher.py
+++ b/apps/target_apps_fetcher.py
@@ -157,6 +157,17 @@ class SkopeAppFetcher(TargetAppsFetcher):
                     with open(os.path.join(blobs_dir, lm_uri.hash), 'wb') as f:
                         f.write(layers_index)
 
+            # If present, then download and store the app layers metadata that contains precise
+            # sizes of extracted layers.
+            # The metadata are used to calculate exact update size during offline update
+            if len(manifest.get('layers', [])) > 1 and \
+                    manifest['layers'][1].get('annotations', {}).get('layers-meta') == 'v1':
+                layer_desc = manifest['layers'][1]
+                blob = self._registry_client.pull_layer(uri, layer_desc['digest'])
+                blob_file = os.path.join(blobs_dir, layer_desc['digest'][len('sha256:'):])
+                with open(blob_file, 'wb') as f:
+                    f.write(blob)
+
             fetched_apps.append(ComposeApps.App(app_name, app_dir))
         return fetched_apps
 


### PR DESCRIPTION
Tiny changes to make the app preloader download and store all nodes/blobs of an app's Merkle tree.
It enables the new compose app management usage on devices for the early app start and offline updates use-cases since it requires presence of all app tree nodes so it can check its integrity.