### PR TITLE
Generate mirror tarball

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -113,6 +113,7 @@ function set_base_lmp_version {
 
 	# 3: Find our base LMP version based on the HEAD
 	export LMP_VERSION=$(git describe --tags --abbrev=0 HEAD)
+	export LMP_VERSION_MINOR="$(git rev-list ${LMP_VERSION}..HEAD --count)"
 	export LMP_VERSION_CACHE="$LMP_VERSION"
 	if [[ "${H_PROJECT}" == "lmp" ]] || [ -v LMP_VERSION_CACHE_DEV ] ; then
 		# Public LmP build - we are building for the *next* release

--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -67,6 +67,13 @@ status "Run bitbake (save the global and image specific environments)"
 bitbake -e > ${archive}/bitbake_global_env.txt
 bitbake -e ${IMAGE} > ${archive}/bitbake_image_env.txt
 
+# Public LmP build and we are building the major release
+if [[ "${H_PROJECT}" == "lmp" ]] && [[ "${LMP_VERSION_MINOR}" == "0" ]] ; then
+    status "Run bitbake (generate mirror tarball)"
+    echo 'BB_GENERATE_MIRROR_TARBALLS = "1"' >> conf/local.conf
+    bitbake --runall fetch --no-setscene ${IMAGE}
+fi
+
 # Setscene (cache), failures not critical
 status "Run bitbake (setscene tasks only)"
 bitbake --setscene-only ${IMAGE} || true


### PR DESCRIPTION
When building public LmP **major release** we will generate the mirror tarball on the download folder of all git repos.

All the download files can be updated to the public download mirror at the end:
```
rsync -av --no-r --exclude=*.done --exclude=*.tmp /downloads/ /download-mirror/
```