### PR TITLE
lmp/jobserv: drop xilinx machines from main-next

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -169,8 +169,6 @@ triggers:
               - jetson-agx-orin-devkit
               - qemuarm64-secureboot
               - raspberrypi4-64
-              - kv260
-              - vck190-versal
         params:
           IMAGE: lmp-base-console-image
           MFGTOOL_FLASH_IMAGE: lmp-base-console-image


### PR DESCRIPTION
We will disable this temporarily to prepare the next LTS. Currently we need to fork most of the layers in main-next and this will reducing maintenance effort and number of build.