### PR TITLE
helpers: Hack around MEDs/oe-builtin issue

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -120,9 +120,13 @@ def fio_dnsbase():
     '''Find the dns base hosting jobserv. For example when running under
        api.foundries.io, this would return foundries.io
     '''
-    parts = urlparse(os.environ["H_RUN_URL"])
-    _, base = parts.netloc.split(".", 1)
-    return base
+    run_url = os.environ.get("H_RUN_URL")
+    if run_url:
+        parts = urlparse(run_url)
+        _, base = parts.netloc.split(".", 1)
+        return base
+    status("WARNING: H_RUN_URL not defined, defaulting fio_dnsbase to be foundries.io")
+    return "foundries.io"
 
 
 def jobserv_get(url):


### PR DESCRIPTION
oe-builtin logic is seeing a CI error like:
| Traceback (most recent call last):
|   File "/script-repo/preload_apps.py", line 14, in <module>
|     from apps.docker_registry_client import ThirdPartyRegistry
|   File "/script-repo/apps/docker_registry_client.py", line 18, in <module>
|     class DockerRegistryClient:
|   File "/script-repo/apps/docker_registry_client.py", line 19, in DockerRegistryClient
|     DefaultRegistryHost = 'hub.' + fio_dnsbase()
|   File "/script-repo/helpers.py", line 123, in fio_dnsbase
|     parts = urlparse(os.environ["H_RUN_URL"])
|   File "/usr/lib/python3.8/os.py", line 675, in __getitem__
|     raise KeyError(key) from None
| KeyError: 'H_RUN_URL'

This is because bitbake isolates the environment that it runs in. There are a couple ways to pass H_RUN_URL in, but they cause a big cache invalidation.

The workaround provided here works as long as we don't have a customer on MEDs that does oe-builtin.