### PR TITLE
Relicense from Apache-v2 to BSD-3 Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,28 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+BSD 3-Clause License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2019-2024, Foundries.io
 
-   1. Definitions.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apps/apps_publisher.py
+++ b/apps/apps_publisher.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import json
 import logging

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: BSD-3-Clause
 #
 # This script will handle the follow scenarios for building containers
 #   * If NOCACHE flag is set, it will rebuild all container images without cache.

--- a/apps/compose_apps.py
+++ b/apps/compose_apps.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import logging
 import os

--- a/apps/docker_registry_client.py
+++ b/apps/docker_registry_client.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import os
 import sys

--- a/apps/docker_to_compose.py
+++ b/apps/docker_to_compose.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import yaml
 import os

--- a/apps/dockerd.py
+++ b/apps/dockerd.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import os
 import time

--- a/apps/fetch.py
+++ b/apps/fetch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2021 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import argparse
 import json

--- a/apps/image_downloader.py
+++ b/apps/image_downloader.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import os
 import logging

--- a/apps/publish.py
+++ b/apps/publish.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import json
 import logging

--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2020 Foundries.io,
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 set -o errexit
 set -o pipefail
 

--- a/apps/target_manager.py
+++ b/apps/target_manager.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 import datetime
 import logging
 import os

--- a/assemble-system-image.sh
+++ b/assemble-system-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -o errexit
 set -o pipefail

--- a/assemble.py
+++ b/assemble.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 #
 import subprocess
 import os

--- a/factory-containers/publish-containers.sh
+++ b/factory-containers/publish-containers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2022 Foundries.io,
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 set -o errexit
 set -o pipefail
 

--- a/lmp/customize-target.py
+++ b/lmp/customize-target.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2019 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 #
 import argparse
 import logging

--- a/lmp/customize-target.sh
+++ b/lmp/customize-target.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -o errexit
 set -o pipefail

--- a/lmp/fetch-root-meta.sh
+++ b/lmp/fetch-root-meta.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2022 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -o errexit
 set -o pipefail

--- a/lmp/fetch_root_meta.py
+++ b/lmp/fetch_root_meta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2022 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import sys
 import os

--- a/preload-apps.sh
+++ b/preload-apps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2022 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -o errexit
 set -o pipefail

--- a/preload_apps.py
+++ b/preload_apps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2022 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 #
 import argparse
 import logging

--- a/tag_manager.py
+++ b/tag_manager.py
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2019 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 class TagMgr:
     def __init__(self, ota_lite_tag=''):

--- a/tests/test_apps_fetch.sh
+++ b/tests/test_apps_fetch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2024 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 set -euo pipefail
 
 FACTORY=$1

--- a/tests/test_apps_publisher.py
+++ b/tests/test_apps_publisher.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 from apps.compose_apps import ComposeApps
 from apps.apps_publisher import AppsPublisher

--- a/tests/test_apps_publishing.sh
+++ b/tests/test_apps_publishing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 set -euo pipefail
 
 # examples

--- a/tests/test_compose_apps.py
+++ b/tests/test_compose_apps.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 from apps.compose_apps import ComposeApps
 

--- a/tests/test_container_build.sh
+++ b/tests/test_container_build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -eu
-# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Foundries.io, SPDX-License-Identifier: BSD-3-Clause
 
 HERE=$(dirname $(readlink -f $0))
 TMPDIR=${TMPDIR-/var/tmp}

--- a/tests/test_container_tagging.py
+++ b/tests/test_container_tagging.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 import json
 import os

--- a/tests/test_image_assembling.sh
+++ b/tests/test_image_assembling.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2020 Foundries.io
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 set -euo pipefail
 
 # Examples


### PR DESCRIPTION
Relicensing from Apache-v2 to BSD-3 Clause in order to align with other open source repositories owned by Foundries.io