### PR TITLE
apps: Convert shortlist string to list

### DIFF
--- a/apps/fetch.py
+++ b/apps/fetch.py
@@ -15,7 +15,7 @@ from factory_client import FactoryClient
 from helpers import cmd
 
 
-def fetch_target_apps(targets: dict, apps_shortlist: str, token: str, dst_dir: str):
+def fetch_target_apps(targets: dict, apps_shortlist: [str], token: str, dst_dir: str):
     apps_fetcher = SkopeAppFetcher(token, dst_dir)
     for target_name, target_json in targets.items():
         apps_fetcher.fetch_target(FactoryClient.Target(target_name, target_json),
@@ -45,6 +45,8 @@ def get_args():
                         help='TUF targets to be updated with URI to fetched app archive')
 
     args = parser.parse_args()
+    if args.apps_shortlist:
+        args.apps_shortlist = [x.strip() for x in args.apps_shortlist.split(',') if x]
     return args
 
 

--- a/apps/target_apps_fetcher.py
+++ b/apps/target_apps_fetcher.py
@@ -41,12 +41,12 @@ class TargetAppsFetcher:
     def images_dir(self, target_name):
         return os.path.join(self.target_dir(target_name), self.ImagesDir)
 
-    def fetch_target(self, target: FactoryClient.Target, shortlist=None, force=False):
+    def fetch_target(self, target: FactoryClient.Target, shortlist: [str] = None, force=False):
         self.target_apps.clear()
         self.fetch_target_apps(target, apps_shortlist=target.shortlist or shortlist, force=force)
         self.fetch_apps_images(force=force)
 
-    def fetch_target_apps(self, target: FactoryClient.Target, apps_shortlist=None, force=False):
+    def fetch_target_apps(self, target: FactoryClient.Target, apps_shortlist: [str] = None, force=False):
         self.target_apps[target] = self._fetch_apps(target, apps_shortlist=apps_shortlist, force=force)
 
     def fetch_apps_images(self, graphdriver='overlay2', force=False):
@@ -71,7 +71,7 @@ class TargetAppsFetcher:
             for app in apps:
                 app.download_images(platform, dockerd.host)
 
-    def _fetch_apps(self, target, apps_shortlist=None, force=False):
+    def _fetch_apps(self, target, apps_shortlist: [str] = None, force=False):
         for app_name, app_uri in target.apps():
             if apps_shortlist and app_name not in apps_shortlist:
                 logger.info('{} is not in the shortlist, skipping it'.format(app_name))


### PR DESCRIPTION
- Convert the comma-separated list of apps represented as a string and provided as an input parameter to a list of string.

- Define the app shortlist as a list of strings in each function of the app fetcher.