### PR TITLE
apps: Convert shortlist string to list

### DIFF
--- a/apps/fetch.py
+++ b/apps/fetch.py
@@ -19,7 +19,8 @@ def fetch_target_apps(targets: dict, apps_shortlist: str, token: str, dst_dir: s
     apps_fetcher = SkopeAppFetcher(token, dst_dir)
     for target_name, target_json in targets.items():
         apps_fetcher.fetch_target(FactoryClient.Target(target_name, target_json),
-                                  apps_shortlist, force=True)
+                                  [x.strip() for x in apps_shortlist.split(',') if x]
+                                  if apps_shortlist else None, force=True)
 
 
 def tar_fetched_apps(src_dir: str, out_file: str):

--- a/assemble.py
+++ b/assemble.py
@@ -276,21 +276,24 @@ def fetch_restorable_apps(target: FactoryClient.Target, dst_dir: str, shortlist:
 def check_and_get_fetched_apps_uri(target: FactoryClient.Target, shortlist: [str] = None):
     fetched_apps = None
     fetched_apps_uri = None
-    if "fetched-apps" in target.json.get("custom", {}):
-        fetched_apps_str = target.json["custom"]["fetched-apps"].get("shortlist")
-        if fetched_apps_str:
-            fetched_apps = set(
-                x.strip() for x in fetched_apps_str.split(',') if x)
-        else:
-            # if `shortlist` is not defined or empty then all target apps were fetched
-            fetched_apps = set(app[0] for app in target.apps())
+    try:
+        if "fetched-apps" in target.json.get("custom", {}):
+            fetched_apps_str = target.json["custom"]["fetched-apps"].get("shortlist")
+            if fetched_apps_str:
+                fetched_apps = set(
+                    x.strip() for x in fetched_apps_str.split(',') if x)
+            else:
+                # if `shortlist` is not defined or empty then all target apps were fetched
+                fetched_apps = set(app[0] for app in target.apps())
 
-        apps_to_fetch = set(shortlist) if shortlist else set(app[0] for app in target.apps())
+            apps_to_fetch = set(shortlist) if shortlist else set(app[0] for app in target.apps())
 
-        if fetched_apps.issubset(apps_to_fetch):
-            # if the previously fetched apps is a sub-set of the apps to be fetched then
-            # enable getting and reusing the previously fetched apps
-            fetched_apps_uri = target.json["custom"]["fetched-apps"]["uri"]
+            if fetched_apps.issubset(apps_to_fetch):
+                # if the previously fetched apps is a sub-set of the apps to be fetched then
+                # enable getting and reusing the previously fetched apps
+                fetched_apps_uri = target.json["custom"]["fetched-apps"]["uri"]
+    except Exception as err:
+        logger.error(f"Failed to get info about fetched apps: {err}")
 
     return fetched_apps_uri, fetched_apps
 


### PR DESCRIPTION
- Convert the comma-separated list of apps represented as a string and provided as an input parameter to a list of string.

- Ignore any error that occurs during checking if apps were fetched before and let the image preloading functionality fetch apps from scratch.