### PR TITLE
Fix/dont set shortlist if none

### DIFF
--- a/factory_client.py
+++ b/factory_client.py
@@ -17,7 +17,8 @@ class FactoryClient:
         def __init__(self, target_name, target_json, shortlist=None):
             self.name = target_name
             self.json = target_json
-            self.shortlist = shortlist
+            if shortlist is not None:
+                self.shortlist = shortlist
             self._set_apps_commit_hash()
 
         @property


### PR DESCRIPTION
Do not set the 'shortlist' attribute in the input JSON if the 'shortlist' input parameter is set to 'None'.Otherwise, the input target JSON will be modified to include the 'shortlist: null' field. This is undesirable during app fetching when the target JSON serves solely as a read-only parameter.

E.g.

```
"origUri": "https://ci.fioed.io/projects/<factory>/lmp/builds/75",
"shortlist": null,
"fetched-apps": {
    "uri": "https://api.fioed.io/projects/<factory>/lmp/builds/80/runs/publish-compose-apps/intel-corei7-64-lmp-80.apps.tar",
    "shortlist": "app-04"
}
```