### PR TITLE
lmp: Build lmp-sdk container image

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+HERE=$(dirname $(readlink -f $0))
+source $HERE/../helpers.sh
+
+TAG=$(git log -1 --format=%h)
+
+status Launching dockerd
+unset DOCKER_HOST
+/usr/local/bin/dockerd-entrypoint.sh --experimental --raw-logs >/archive/dockerd.log 2>&1 &
+for i in `seq 12` ; do
+	sleep 1
+	docker info >/dev/null 2>&1 && break
+	if [ $i = 12 ] ; then
+		status Timed out trying to connect to internal docker host
+		exit 1
+	fi
+done
+
+container="hub.foundries.io/lmp-sdk"
+tagged="${container}:${TAG}"
+latest="${container}:latest"
+
+docker_login
+
+run docker build -t ${tagged} -t ${latest} .
+run docker push ${tagged}
+run docker push ${latest}

--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -15,6 +15,13 @@ triggers:
         refs/heads/main
       OTA_LITE_TAG: main
     runs:
+      - name: lmp-sdk
+        host-tag: amd64
+        container: foundries/dind-ci:19.03.9_b38f166
+        privileged: true
+        script-repo:
+          name: fio
+          path: lmp/build-sdk-container.sh
       # images with no OTA
       - name: "{loop}"
         container: hub.foundries.io/lmp-sdk


### PR DESCRIPTION
We had this logic in our old gitlab server and never migrated. The time has come.