### PR TITLE
apps: Add shortlist field to target only if set

### DIFF
--- a/apps/fetch.py
+++ b/apps/fetch.py
@@ -64,8 +64,10 @@ def main(args: argparse.Namespace):
             tar_fetched_apps(os.path.join(args.fetch_dir, target), out_file)
             target_json["custom"]["fetched-apps"] = {
                 "uri": os.path.join(os.environ["H_RUN_URL"], f"{target}.apps.tar"),
-                "shortlist": args.apps_shortlist,
             }
+            if args.apps_shortlist:
+                target_json["custom"]["fetched-apps"]["shortlist"] = args.apps_shortlist
+
         with open(args.targets_file, "w") as f:
             json.dump(targets, f)
 


### PR DESCRIPTION
Don't set `shortlist` field in the custom.fetched-apps.shortlist field of a target if the `shortlist` attribute is not defined in `preloaded_images` nor `app_shortlist is defined in in `offline` sections of a factory config.