### PR TITLE
lmp/jobserv: add scarthgap-next

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -231,6 +231,102 @@ triggers:
         persistent-volumes:
           bitbake: /var/cache/bitbake
 
+  - name: build-scarthgap-next
+    type: git_poller
+    email:
+      users: 'ci-notifications@foundries.io'
+    webhooks:
+      - url: https://conductor.infra.foundries.io/api/lmp/
+        only_failures: false
+        secret_name: lava-webhook-key
+    params:
+      GIT_URL: |
+        https://github.com/foundriesio/lmp-manifest.git
+      GIT_POLL_REFS: |
+        refs/heads/scarthgap-next
+      OTA_LITE_TAG: 'scarthgap-next:scarthgap'
+      AKLITE_TAG: promoted-scarthgap
+    runs:
+      # images with no OTA
+      - name: "{loop}"
+        container: hub.foundries.io/lmp-sdk
+        host-tag: amd64-partner-gcp-nocache
+        loop-on:
+          - param: MACHINE
+            values:
+              - am62xx-evm
+              - am64xx-evm
+              - beaglebone-yocto
+              - generic-arm64
+              - intel-corei7-64
+              - imx6ullevk
+              - imx6ullevk-sec
+              - imx8mm-lpddr4-evk
+              - imx8mp-lpddr4-evk
+              - imx8mn-ddr4-evk
+              - imx8mn-lpddr4-evk
+              - imx8mq-evk
+              - imx8ulp-lpddr4-evk
+              - imx93-11x11-lpddr4x-evk
+              - jetson-agx-xavier-devkit
+              - jetson-agx-orin-devkit
+              - qemuarm64-secureboot
+              - raspberrypi4-64
+        params:
+          IMAGE: lmp-base-console-image
+          MFGTOOL_FLASH_IMAGE: lmp-base-console-image
+          EULA_stm32mp1eval: "1"
+          EULA_stm32mp1disco: "1"
+        script-repo:
+          name: fio
+          path: lmp/build.sh
+        persistent-volumes:
+          bitbake: /var/cache/bitbake
+
+      # mfgtool / uuu related build files
+      - name: mfgtool-{loop}
+        container: hub.foundries.io/lmp-sdk
+        host-tag: amd64-partner-gcp-nocache
+        loop-on:
+          - param: MACHINE
+            values:
+              - imx6ullevk
+              - imx6ullevk-sec
+              - imx8mm-lpddr4-evk
+              - imx8mp-lpddr4-evk
+              - imx8mn-ddr4-evk
+              - imx8mn-lpddr4-evk
+              - imx8mq-evk
+              - imx8ulp-lpddr4-evk
+              - imx93-11x11-lpddr4x-evk
+        params:
+          DISTRO: lmp-mfgtool
+          IMAGE: mfgtool-files
+          EXTRA_ARTIFACTS: "mfgtool-files.tar.gz"
+        script-repo:
+          name: fio
+          path: lmp/build.sh
+        persistent-volumes:
+          bitbake: /var/cache/bitbake
+
+      # wayland distro flavor
+      - name: build-lmp-wayland-{loop}
+        container: hub.foundries.io/lmp-sdk
+        host-tag: amd64-partner-gcp-nocache
+        loop-on:
+          - param: MACHINE
+            values:
+              - imx8mm-lpddr4-evk
+              - intel-corei7-64
+        params:
+          DISTRO: lmp-wayland
+          IMAGE: lmp-base-console-image
+        script-repo:
+          name: fio
+          path: lmp/build.sh
+        persistent-volumes:
+          bitbake: /var/cache/bitbake
+
   - name: build-release-stable
     type: git_poller
     email:


### PR DESCRIPTION
The scarthgap-next branch is to start exercising the scarthgap release on the ci.