### PR TITLE
Handle offline fetch apps edge cases

### DIFF
--- a/apps/fetch.py
+++ b/apps/fetch.py
@@ -22,13 +22,18 @@ def fetch_target_apps(targets: dict, apps_shortlist: set[str], token: str, dst_d
         target = FactoryClient.Target(target_name, target_json)
         target_apps = set(app for app, _ in target.apps())
         target_app_shortlist: set[str] = None
+        excluded_apps: set[str] = None
         if apps_shortlist:
             target_app_shortlist = target_apps.intersection(apps_shortlist)
+            excluded_apps = apps_shortlist.difference(target_app_shortlist)
 
         if apps_shortlist and not target_app_shortlist:
             raise Exception(f'No apps found to fetch; target: {target_name};'
                             f' target apps: {",".join(target_apps)};'
                             f' shortlist: {",".join(apps_shortlist)}')
+        if excluded_apps and len(excluded_apps) > 0:
+            logging.info(f'"{",".join(excluded_apps)}" are excluded from the final shortlist '
+                         f'because they are not among target apps: {",".join(target_apps)}')
         logging.info(f'"{",".join(target_app_shortlist if target_app_shortlist else target_apps)}"'
                      f' will be pulled for {target_name}')
         apps_fetcher.fetch_target(target, target_app_shortlist, force=True)
@@ -51,13 +56,16 @@ def get_args():
     parser.add_argument('-a', '--token-file',
                         help='File where the Factory API Token is stored', required=True)
     parser.add_argument('-d', '--fetch-dir',
-                        help='Directory to fetch apps and images to', required=True)
+                        help='Directory to fetch apps and images to', required=False)
     parser.add_argument('-s', '--apps-shortlist',
                         help='Comma separated list of Target Apps to fetch', default=None)
     parser.add_argument('-o', '--dst-dir',
                         help='Directory to output the tarred apps data to', required=True)
     parser.add_argument('-tt', '--tuf-targets',
                         help='TUF targets to be updated with URI to fetched app archive')
+    parser.add_argument('-dd', '--disable',
+                        help='TUF targets to be updated with URI to fetched app archive',
+                        default=False, action='store_true')
 
     args = parser.parse_args()
     return args
@@ -71,20 +79,27 @@ def main(args: argparse.Namespace):
         with open(args.targets_file) as f:
             targets = json.load(f)
 
-        shortlist = [x.strip() for x in args.apps_shortlist.split(',') if x] \
-            if args.apps_shortlist else None
+        if args.disable:
+            logging.info("Disabling apps for offline update...")
+            for target, target_json in targets.items():
+                target_json["custom"]["fetched-apps"] = {
+                    "uri": None
+                }
+        else:
+            shortlist = set([x.strip() for x in args.apps_shortlist.split(',') if x]) \
+                if args.apps_shortlist else None
 
-        fetched_target_apps = fetch_target_apps(targets, shortlist, token, args.fetch_dir)
-        for target, target_json in targets.items():
-            out_file = os.path.join(args.dst_dir, f"{target}.apps.tar")
-            logging.info(f"Tarring fetched apps of {target} to {out_file}...")
-            tar_fetched_apps(os.path.join(args.fetch_dir, target), out_file)
-            target_json["custom"]["fetched-apps"] = {
-                "uri": os.path.join(os.environ["H_RUN_URL"], f"{target}.apps.tar"),
-            }
-            if fetched_target_apps[target] and len(fetched_target_apps[target]) > 0:
-                target_json["custom"]["fetched-apps"]["shortlist"] = \
-                                                            ",".join(fetched_target_apps[target])
+            fetched_target_apps = fetch_target_apps(targets, shortlist, token, args.fetch_dir)
+            for target, target_json in targets.items():
+                out_file = os.path.join(args.dst_dir, f"{target}.apps.tar")
+                logging.info(f"Tarring fetched apps of {target} to {out_file}...")
+                tar_fetched_apps(os.path.join(args.fetch_dir, target), out_file)
+                target_json["custom"]["fetched-apps"] = {
+                    "uri": os.path.join(os.environ["H_RUN_URL"], f"{target}.apps.tar"),
+                }
+                if fetched_target_apps[target] and len(fetched_target_apps[target]) > 0:
+                    target_json["custom"]["fetched-apps"]["shortlist"] = \
+                                                                ",".join(fetched_target_apps[target])
 
         with open(args.targets_file, "w") as f:
             json.dump(targets, f)

--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -105,6 +105,15 @@ if [ "${FETCH_APPS}" == "1" ]; then
       --apps-shortlist="${FETCH_APPS_SHORTLIST}" \
       --dst-dir="${ARCHIVE}" \
       --tuf-targets="${TUF_REPO}/roles/unsigned/targets.json"
+elif [ "${FETCH_APPS}" == "0" ]; then
+  status "Disabling apps update for offline update..."
+  "${HERE}/fetch.py" \
+      --factory "${FACTORY}" \
+      --targets-file="${ARCHIVE}/targets-created.json" \
+      --token-file="${SECRETS}/osftok" \
+      --disable \
+      --dst-dir="${ARCHIVE}" \
+      --tuf-targets="${TUF_REPO}/roles/unsigned/targets.json"
 fi
 
 cp "${TUF_REPO}/roles/unsigned/targets.json" "${ARCHIVE}/targets-after.json"


### PR DESCRIPTION
1. Add ability to disable apps update for offline update.
    It adds the `fetched-apps.uri=None` value to each target, so the
    target consumer, fioctl and aklite-offline, knows whether
    to consider apps for the target offline update or not.

2. Don't set `fetched-apps.shortlist` field if shortlist is not specified or empty value.    
    - Use target apps and shortlist intersection as the shortlist of apps to
      fetch. Also, set the `fetched-apps.shortlist` value to this
      intersection.
    
    - Yield an error if no apps found to fetch for the given intersection of
      target apps and the specified shortlist.

