### PR TITLE
apps: Fetch app images if sbom is turned off

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -222,6 +222,8 @@ done
 
 if [ -z "$DISABLE_SBOM" ] ; then
 	PYTHONPATH=${HERE}/.. python3 ${HERE}/generate_non_factory_sboms.py --arch=$ARCH
+else
+  PYTHONPATH="${HERE}"/.. python3 "${HERE}"/fetch_app_images.py --apps-root "${REPO_ROOT}" --tag "${TAG}-${ARCH}"
 fi
 # 1. Parse the local docker store (the one where the built images are stored).
 # 2. Extract layers metadata (size, usage) of all Apps' images

--- a/apps/fetch_app_images.py
+++ b/apps/fetch_app_images.py
@@ -1,0 +1,41 @@
+import argparse
+import logging
+import os
+import subprocess
+
+from apps.compose_apps import ComposeApps
+from apps.apps_publisher import AppsPublisher
+from helpers import status
+
+
+def main(args):
+    status("Fetching app images to the local docker engine store")
+
+    publisher = AppsPublisher(args.factory, "", "")
+    apps = ComposeApps(args.apps_root, quiet=True)
+    publisher.tag(apps, args.tag)
+    for app in apps:
+        subprocess.check_call(["docker", "compose", "--project-directory", app.dir, "pull"])
+
+
+def get_args():
+    factory = os.environ.get("FACTORY")
+    arch = os.environ.get("ARCH")
+    parser = argparse.ArgumentParser("Pull app images into a local docker store")
+    parser.add_argument("--factory", default=factory)
+    parser.add_argument("--apps-root", default="./")
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--arch", default=arch)
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s %(levelname)s: %(module)s: %(message)s', level=logging.INFO)
+    args = get_args()
+
+    # FACTORY must be set so that expandvars above will work correctly for
+    # service images like: hub.foundries.io/${FACTORY}/foo
+    os.environ["FACTORY"] = args.factory
+    main(args)
+


### PR DESCRIPTION
Pull app images if the sbom generation is turned off.
If the sbom generation is turned ON, it pulls all app images to the local docker store. Then, the following script that gather information about app image layers parses the local docker store, therefore it assumes that all app images are present in the store.
If the sbom generation is OFF, then the 3rd party images are not present in the local store, hence they must be fetched to make the app layer metadata generation script work correctly. This is exactly what this change does.