### PR TITLE
lmp: Support partner mirrors

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -193,12 +193,16 @@ IMAGE_LICENSE_CHECKER_NON_ROOTFS_DENYLIST = "GPL-3.0-only GPL-3.0-or-later LGPL-
 EOFEOF
 fi
 
+sstate_mirror="https://storage.googleapis.com/lmp-cache/v${LMP_VERSION_CACHE}-sstate-cache"
+if [[ "${FORKED_FROM}" != "lmp" ]] ; then
+	sstate_mirror="https://storage.googleapis.com/lmp-cache/${FORKED_FROM}/v${LMP_VERSION_CACHE}-sstate-cache"
+fi
 	cat << EOFEOF >> conf/local.conf
 
 # prioritize local nfs factory mirror over public https lmp
 SSTATE_MIRRORS ?= " \\
 	file://.* file://${FACTORY_SSTATE_CACHE_MIRROR}/PATH \\
-	file://.* https://storage.googleapis.com/lmp-cache/v${LMP_VERSION_CACHE}-sstate-cache/PATH \\
+	file://.* ${sstate_mirror}/PATH \\
 "
 EOFEOF
 


### PR DESCRIPTION
We are introducing the ability for our partner factories to have sstate mirror objects in GCS. This change detects that based on the "forked-from" attribute we use a factory's factory-config.yml that will get set by our git server as a CI run parameter when triggering a build.