### PR TITLE
helpers: Support minor releases of LmP in mirror code

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -114,7 +114,7 @@ function set_base_lmp_version {
 	# 3: Find our base LMP version based on the HEAD
 	export LMP_VERSION=$(git describe --tags --abbrev=0 HEAD)
 	export LMP_VERSION_MINOR="$(git rev-list ${LMP_VERSION}..HEAD --count)"
-	export LMP_VERSION_CACHE="$LMP_VERSION"
+	export LMP_VERSION_CACHE="$(echo $LMP_VERSION | sed 's/\.[0-9]*$//')"
 	if [[ "${H_PROJECT}" == "lmp" ]] || [ -v LMP_VERSION_CACHE_DEV ] ; then
 		# Public LmP build - we are building for the *next* release
 		LMP_VERSION_CACHE=$(( $LMP_VERSION_CACHE + 1 ))


### PR DESCRIPTION
We are about to release a 94.1 version of the LmP. In the event of a 94.1 tag, we want to truncate the value and still use the "94" cache. This also allows the development of "95" to continue correctly.

The drawback to this approach is that the .1 part of the sstate cache is actually in the 95 bucket. 94.1 is small enough this doesn't matter. If we ever have a minor release that causes sufficient cache invalidation, then we'll need to re-think how to produce the cache better.