### PR TITLE
factory_client: Support LmP minor version conversion to int

### DIFF
--- a/factory_client.py
+++ b/factory_client.py
@@ -94,7 +94,7 @@ class FactoryClient:
             # <yocto-version>-<commit-numb-after-tag>-<lmp-version>-<commit-numb-after-tag>-<abbreviated commit hash>
             version = release_info['VERSION'].strip('"')
             version_data = version.split('-')
-            lmp_version = int(version_data[2]) if len(version_data) > 2 else 0
+            lmp_version = int(float(version_data[2])) if len(version_data) > 2 else 0
             yocto_version = version_data[0] if len(version_data) >= 1 else None
             return cls(lmp_version, yocto_version)
 


### PR DESCRIPTION
Convert LmP version to float prior to converting it to int so minor LmP release versions are supported, e.g. "94.1".