### PR TITLE
apps/publish: Print publish tool path if non-default

### DIFF
--- a/apps/publish.sh
+++ b/apps/publish.sh
@@ -55,6 +55,8 @@ if [ ! -f "${PUBLISH_TOOL}" ]; then
   PUBLISH_TOOL="/tmp/compose-publish"
   run wget -O ${PUBLISH_TOOL} https://storage.googleapis.com/subscriber_registry/compose-publish
   chmod +x ${PUBLISH_TOOL}
+else
+  status "${PUBLISH_TOOL} will be used for publishing apps"
 fi
 
 export PYTHONPATH=${HERE}/../


### PR DESCRIPTION
Just tiny improvement that helps to identify an app publishing tool if the default one is override through setting the `PUBLISH_TOOL` env. variable.