### PR TITLE
lmp/bb-config: temporarily disable our custom logconfig

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -136,7 +136,7 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
 
 # Bitbake custom logconfig
-BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
+#BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
 
 # Custom repo for OP-TEE
 OPTEE_OS_REPO ?= "git://git.codelinaro.org/clo/foundriesio/optee_os.git"


### PR DESCRIPTION
Looks like bitbake is getting blocked just on the beginning when checking the sstate-mirror. 
Because we have custom log config we can't see the debug output on the default console and this change will make it possible.