### PR TITLE
apps/build.sh: Make dockerd listen only on unix socket

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -48,7 +48,7 @@ file /bin/busybox | grep -q armhf && ARCH=arm || true
 
 status Launching dockerd
 unset DOCKER_HOST
-/usr/local/bin/dockerd-entrypoint.sh --experimental --raw-logs >/archive/dockerd.log 2>&1 &
+/usr/local/bin/dockerd-entrypoint.sh dockerd --experimental --raw-logs >/archive/dockerd.log 2>&1 &
 for i in `seq 12` ; do
 	sleep 1
 	docker info >/dev/null 2>&1 && break


### PR DESCRIPTION
Makes the `dockerd-entrypoint.sh` script to run dockerd in the way it listens only the usual unix socket and avoiding listening on network ports `2375` or `2376`.
Also, it seems important to run the docked through `/usr/local/bin/dind`. 