### PR TITLE
Control the bitbake logconfig

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -76,7 +76,7 @@ fi
 
 # Setscene (cache), failures not critical
 status "Run bitbake (setscene tasks only)"
-bitbake --setscene-only ${IMAGE} || true
+bitbake -DD --setscene-only ${IMAGE} || true
 
 # add trap to do some pending operations on exit
 trap finish TERM INT EXIT
@@ -86,4 +86,4 @@ if [ "$BUILD_SDK" == "1" ] && [ "${DISTRO}" != "lmp-mfgtool" ]; then
     bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE} -c populate_sdk
 fi
 status "Run bitbake"
-bitbake -D ${BITBAKE_EXTRA_ARGS} ${IMAGE}
+bitbake -DD ${BITBAKE_EXTRA_ARGS} ${IMAGE}

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -24,6 +24,7 @@ OSTREE_API_VERSION="${OSTREE_API_VERSION-v2}"
 DEV_MODE="${DEV_MODE-0}"
 BUILD_SDK="${BUILD_SDK-0}"
 LMP_ROLLBACK_PROTECTION_ENABLE="${LMP_ROLLBACK_PROTECTION_ENABLE-0}"
+DISABLE_LOGCONFIG="${DISABLE_LOGCONFIG-0}"
 
 GARAGE_CUSTOMIZE_TARGET_PARAMS='${MACHINE} ${IMAGE_BASENAME} ${TARGET_ARCH} ${DISTRO_VERSION}'
 TUF_TARGETS_EXPIRE="${TUF_TARGETS_EXPIRE-1Y}"
@@ -135,12 +136,17 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 # mfgtool params
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
 
-# Bitbake custom logconfig
-BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
-
 # Custom repo for OP-TEE
 OPTEE_OS_REPO ?= "git://git.codelinaro.org/clo/foundriesio/optee_os.git"
 EOFEOF
+
+if [ "${DISABLE_LOGCONFIG}" != "1" ]; then
+	cat << EOFEOF >> conf/local.conf
+
+# Bitbake custom logconfig
+BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
+EOFEOF
+fi
 
 # Configure path for the debug/warning logs
 sed -e "s|@@ARCHIVE@@|${archive}|" ${HERE}/bb_logconfig.json > bb_logconfig.json

--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -136,7 +136,7 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
 
 # Bitbake custom logconfig
-#BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
+BB_LOGCONFIG = "${PWD}/bb_logconfig.json"
 
 # Custom repo for OP-TEE
 OPTEE_OS_REPO ?= "git://git.codelinaro.org/clo/foundriesio/optee_os.git"


### PR DESCRIPTION
Add DISABLE_LOGCONFIG variable
    
When this was set to DISABLE_LOGCONFIG=1, the custom logconfig was disabled.
    
The custom logconfig when enabled, which is what we have by default, redirect the output to a file omitting it from appearing in the default build console.
