### PR TITLE
lmp/jobserv: remove the TI machines on the scarthgap-next

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -250,8 +250,6 @@ triggers:
         loop-on:
           - param: MACHINE
             values:
-              - am62xx-evm
-              - am64xx-evm
               - beaglebone-yocto
               - generic-arm64
               - intel-corei7-64


### PR DESCRIPTION
For the v95 scarthgap based the meta-ti layer are not compatible with the scarthgap-next oe-core fork we currently have but it builds without it well. So I will remove the TI layer and machines from CI job because it brings no value to continue to exercise this than always fails.