### PR TITLE
lmp/build.sh: deploy lockdown firmware

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -173,6 +173,7 @@ if [ -d "${archive}" ] ; then
 	cp ${DEPLOY_DIR_IMAGE}/bl*.img ${archive}/other/ || true
 	cp ${DEPLOY_DIR_IMAGE}/fip.bin ${archive}/other/ || true
 	cp ${DEPLOY_DIR_IMAGE}/lk.bin ${archive}/other/ || true
+	cp ${DEPLOY_DIR_IMAGE}/LockDown.efi ${archive}/other/ || true
 	# BSP specific files
 	cp ${DEPLOY_DIR_IMAGE}/rity.json ${archive}/other/ || true
 	# Copy boot.cmd and boot.itb (signed boot script) if available


### PR DESCRIPTION
Simple lockdown script for UEFI Secure Boot.