### PR TITLE
Fix digests of layers meta

### DIFF
--- a/apps/docker_store.py
+++ b/apps/docker_store.py
@@ -140,7 +140,7 @@ class DockerStore:
                     ["skopeo", "inspect", f"docker://{self._image_ref}"])
                 image_desc = json.loads(output)
                 for layer in image_desc["Layers"]:
-                    self._layer_digests.append(layer[len(self._SUPPORTED_HASH_TYPE):])
+                    self._layer_digests.append(layer)
 
                 if len(self._layer_digests) <= idx:
                     raise Exception("the number of image layer diffIDs and layer digests does not"


### PR DESCRIPTION
Fix two issues detected while testing edge cases.

1. Layer digests should be set and used in a full format with the algorithm prefix.
2. Take into account that the docker daemon uses short form references for images hosted in docker.io during getting information about image layers.