### PR TITLE
lmp/bb-build: run the setscene-only job as much as possible

### DIFF
--- a/lmp/bb-build.sh
+++ b/lmp/bb-build.sh
@@ -76,7 +76,7 @@ fi
 
 # Setscene (cache), failures not critical
 status "Run bitbake (setscene tasks only)"
-bitbake -DD --setscene-only ${IMAGE} || true
+bitbake -DD --setscene-only --continue ${IMAGE} || true
 
 # add trap to do some pending operations on exit
 trap finish TERM INT EXIT


### PR DESCRIPTION
This will run all pending do_rm_work task in the bitbake job instead of leaving it for the next job.
This way we don't see do_rm_work task on the next bitbake job that were left here by the previous one.