### PR TITLE
Revert "apps: Use source image format for destination"

### DIFF
--- a/apps/target_apps_fetcher.py
+++ b/apps/target_apps_fetcher.py
@@ -183,7 +183,7 @@ class SkopeAppFetcher(TargetAppsFetcher):
         image_dir = os.path.join(dst_root_dir, uri.host, uri.name, uri.hash)
         os.makedirs(image_dir, exist_ok=True)
         subprocess.check_call(['skopeo', '--insecure-policy', '--override-arch', arch, 'copy',
-                               '--retry-times', '3', '--dest-shared-blob-dir',
+                               '--retry-times', '3', '--format', 'v2s2', '--dest-shared-blob-dir',
                                self.blobs_dir(target_name), 'docker://' + image, 'oci:' + image_dir])
 
         # Store the image manifest in the blob directory, as result it contains all blobs/nodes of


### PR DESCRIPTION
It turned out that not enforcing the docker format for destination causes an issue if docker compose refers to an image manifest (usually compose refers to image index). For some reason `skopeo` don't copy/pull the original config blob referenced from an image manifest if the `--format` is not specified. It converts the original config blob and stores the converted blob...