### PR TITLE
helpers: Use shallow clones for android repo

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -75,7 +75,7 @@ function repo_sync {
 		git config --global http.https://${domain}/factories.extraheader "$(cat /secrets/git.http.extraheader)"
 	fi
 	for i in $(seq 4); do
-		run repo init --repo-rev=v2.35 --no-clone-bundle -u $* ${REPO_INIT_OVERRIDES} && break
+		run repo init --depth=1 --repo-rev=v2.35 --no-clone-bundle -u $* ${REPO_INIT_OVERRIDES} && break
 		status "repo init failed with error $?"
 		[ $i -eq 4 ] && exit 1
 		status "sleeping and trying again"
@@ -93,6 +93,18 @@ function repo_sync {
 			exit $?
 		fi
 	done
+	# NOTE: we need a shallow copy of all the repos, but a deep copy of
+	# lmp-manifests so we can include the LmP version into the build.
+	pushd .repo/manifests.git >/dev/null
+	for i in $(seq 4); do
+		run git fetch --unshallow && break
+		status "git-fetch of lmp-manifests failed with error $?"
+		[ $i -eq 4 ] && exit 1
+		status "sleeping and trying again"
+		sleep $(($i*2))
+	done
+	popd
+
 	if [ -d "$archive" ] ; then
 		status "Generating pinned manifest"
 		repo manifest -r -o $archive/manifest.pinned.xml


### PR DESCRIPTION
We don't need full repo histories when syncing. This will make CI a little faster and less error prone.