### PR TITLE
lmp/build: Improve license and source-code handling

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -101,7 +101,9 @@ for img in ${IMAGE_MANIFESTS}; do
 		ln -sf ${image_name_id}.license.manifest ${DEPLOY_DIR_IMAGE}/${image_name}.license.manifest
 	else
 		status "Image ${image_name} license manifest not found on ${DEPLOY_DIR}/licenses, license manifest can't be collected"
-		exit 1
+		# FIXME: there is a bug in oe-core and sometimes the lic folder is empty
+		# https://bugzilla.yoctoproject.org/show_bug.cgi?id=15394
+		#exit 1
 	fi
 	# Also take care of the image_license, which contains the binaries used by wic outside the rootfs
 	if [ -f ${image_path}/image_license.manifest ]; then


### PR DESCRIPTION
**- License handling**

Instead of blindly failing, this will improve the situation and will show up what is the missing manifests.

- Skip lmp-mfgtool disto variant ()
- Fail if the image manifest not exist
- Consider only the symbolic links of the images manifest
- From the licenses deploy dir of the image:
 - Copy the license.manifest, if not possible fail
 - Copy the image_license.manifest

_For the lmp-mfgtool we don't produce an image and don't make sense to processes the image manifest._

The following is an example of such blindly CI build fail:
```
| + for img in ${DEPLOY_DIR_IMAGE}/*${MACHINE}.manifest
| ++ basename '/srv/oe/build/deploy/images/intel-corei7-64/*intel-corei7-64.manifest'
| ++ sed -e s/.manifest//
| + image_name='*intel-corei7-64'
| ++ readlink '/srv/oe/build/deploy/images/intel-corei7-64/*intel-corei7-64.manifest'
| ++ sed -e 's/\..*manifest//'
| + image_name_id=
| Script completed with error(s)
```

**- Source-code handling**

Adding support for collecting duplicated sources

On multiconfig machines the sources and the license can be duplicated.
We have two places with the source-code and licenses on the ti bsp [1].
If it was the case we will deploy only one package, we will search for the first package license path and use that.

We can also escape and jump this source-code collecting step when we not have any IMAGE_MANIFESTS (i.e no image produced).

[1] https://github.com/foundriesio/meta-lmp/blob/7657b41046ff745ce5fe61a64f615623ebb098e0/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc#L457-L459