### PR TITLE
lmp/jobserv: alling the jobs build-release build-scarthgap

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -51,17 +51,9 @@ triggers:
               - jetson-agx-orin-devkit
               - qemuarm64-secureboot
               - raspberrypi4-64
-              - stm32mp15-disco
-              - stm32mp15-disco-sec
-              - stm32mp15-eval
-              - stm32mp15-eval-sec
-              - kv260
-              - vck190-versal
         params:
           IMAGE: lmp-base-console-image
           MFGTOOL_FLASH_IMAGE: lmp-base-console-image
-          EULA_stm32mp15eval: "1"
-          EULA_stm32mp15disco: "1"
         script-repo:
           name: fio
           path: lmp/build.sh
@@ -91,25 +83,6 @@ triggers:
           DISTRO: lmp-mfgtool
           IMAGE: mfgtool-files
           EXTRA_ARTIFACTS: "mfgtool-files.tar.gz"
-        script-repo:
-          name: fio
-          path: lmp/build.sh
-        persistent-volumes:
-          bitbake: /var/cache/bitbake
-
-      # STM32 mfgtool
-      - name: mfgtool-{loop}
-        container: hub.foundries.io/lmp-sdk
-        host-tag: amd64-partner-gcp-nocache
-        loop-on:
-          - param: MACHINE
-            values:
-              - stm32mp15-disco-sec
-              - stm32mp15-eval-sec
-        params:
-          DISTRO: lmp-mfgtool
-          IMAGE: stm32-mfgtool-files
-          EXTRA_ARTIFACTS: "stm32-mfgtool-files.tar.gz"
         script-repo:
           name: fio
           path: lmp/build.sh

--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -51,6 +51,7 @@ triggers:
               - jetson-agx-orin-devkit
               - qemuarm64-secureboot
               - raspberrypi4-64
+              - raspberrypi5
         params:
           IMAGE: lmp-base-console-image
           MFGTOOL_FLASH_IMAGE: lmp-base-console-image


### PR DESCRIPTION
This will use the same set of machines on two jobs:

build-release:
- track the lmp-manifest/main branch

build-scarthgap:
- track the lmp-manifest/scarthgap branch
