### PR TITLE
Enforce image artifact naming

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -199,8 +199,8 @@ if [ -d "${archive}" ] ; then
 	cp ${DEPLOY_DIR_SDK}/lmp*.sh ${archive}/sdk/ || true
 
 	# Remove ota-ext4 in case the compressed format is available (to reduce time spent uploading)
-	if [ -f ${archive}/other/${IMAGE}-${MACHINE}.ota-ext4.gz ]; then
-		rm -f ${archive}/other/${IMAGE}-${MACHINE}.ota-ext4
+	if [ -f ${archive}/other/${IMAGE}-${MACHINE}.ota-ext4.gz ] || [ -f ${archive}/other/${IMAGE}-${MACHINE}.rootfs.ota-ext4.gz ]; then
+		rm -f ${archive}/other/${IMAGE}-${MACHINE}*.ota-ext4
 	fi
 
 	# Make the main img.gz and respective bmap file be in the root of the archive

--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -204,8 +204,8 @@ if [ -d "${archive}" ] ; then
 	fi
 
 	# Make the main img.gz and respective bmap file be in the root of the archive
-	mv ${archive}/other/lmp-*.wic.gz ${archive}/ || true
-	mv ${archive}/other/lmp-*.wic.bmap ${archive}/ || true
+	mv ${archive}/other/lmp-*.wic.gz ${archive}/${IMAGE}-${MACHINE}.wic.gz || true
+	mv ${archive}/other/lmp-*.wic.bmap ${archive}/${IMAGE}-${MACHINE}.wic.bmap || true
 	# Qcom targets use a qcomflash tarball
 	mv ${archive}/other/lmp-*.qcomflash.tar.gz ${archive}/ || true
 	# NVIDIA targets use a tegraflash tarball


### PR DESCRIPTION
1. Make sure that the CI artifact of the image bitbaked by the LmP build is named according to the expected schema, i.e. `${IMAGE}-${MACHINE}.wic.gz`., e.g. `lmp-factory-image-intel-corei7-64.wic.gz`.

2. Take into account that the `ota-ext4` file can be prefixed with `rootfs in the newer versions of yocto/LmP. We need to take into account both naming schemas, with and without the prefix.

