### PR TITLE
Revert "lmp/bb-config.sh: add custom repo for optee_os"

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -137,9 +137,6 @@ DOCKER_MAX_DOWNLOAD_ATTEMPTS = "${DOCKER_MAX_DOWNLOAD_ATTEMPTS}"
 
 # mfgtool params
 MFGTOOL_FLASH_IMAGE = "${MFGTOOL_FLASH_IMAGE}"
-
-# Custom repo for OP-TEE
-OPTEE_OS_REPO ?= "git://git.codelinaro.org/clo/foundriesio/optee_os.git"
 EOFEOF
 
 if [ "${DISABLE_LOGCONFIG}" != "1" ]; then


### PR DESCRIPTION
This reverts commit ac2a7a510df38a59860618badbe73243957b56cb.

The repo is available again at Foundries.io github

- git://github.com/foundriesio/optee_os.git