### PR TITLE
lmp/bb-config: add v95 no-gplv3 config

### DIFF
--- a/lmp/bb-config.sh
+++ b/lmp/bb-config.sh
@@ -189,13 +189,20 @@ EOFEOF
 fi
 
 if [ "${DISABLE_GPLV3}" = "1" ]; then
-	cat << EOFEOF >> conf/local.conf
+	# supported in v95
+	if [ -f ../layers/meta-lmp-base/conf/distro/include/lmp-no-gplv3.inc ]; then
+		cat << EOFEOF >> conf/local.conf
+require conf/distro/include/lmp-no-gplv3.inc
+EOFEOF
+	else
+		cat << EOFEOF >> conf/local.conf
 INHERIT += "image-license-checker lmp-disable-gplv3"
 IMAGE_LICENSE_CHECKER_ROOTFS_BLACKLIST = "GPL-3.0 LGPL-3.0 AGPL-3.0"
 IMAGE_LICENSE_CHECKER_NON_ROOTFS_BLACKLIST = "GPL-3.0 LGPL-3.0 AGPL-3.0"
 IMAGE_LICENSE_CHECKER_ROOTFS_DENYLIST = "GPL-3.0-only GPL-3.0-or-later LGPL-3.0* AGPL-3.0*"
 IMAGE_LICENSE_CHECKER_NON_ROOTFS_DENYLIST = "GPL-3.0-only GPL-3.0-or-later LGPL-3.0* AGPL-3.0*"
 EOFEOF
+	fi
 fi
 
 sstate_mirror="https://storage.googleapis.com/lmp-cache/v${LMP_VERSION_CACHE}-sstate-cache"


### PR DESCRIPTION
With the v95 we droped the image-license-checker and lmp-disable-gplv3 bbclass. https://github.com/foundriesio/meta-lmp/pull/1618