### PR TITLE
lmp/build-sdk-container: override the latest tag via an environment variable

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -3,7 +3,7 @@
 HERE=$(dirname $(readlink -f $0))
 source $HERE/../helpers.sh
 
-TAG=$(git log -1 --format=%h)
+LATEST=${LATEST:-latest}
 
 status Launching dockerd
 unset DOCKER_HOST
@@ -18,11 +18,15 @@ for i in `seq 12` ; do
 done
 
 container="hub.foundries.io/lmp-sdk"
-tagged="${container}:${TAG}"
-latest="${container}:latest"
+# override tag if passed as argument
+tags="${LATEST}"
+if [ "${tags}" == "latest" ]; then
+	# add latest tag
+	tags="$(git log -1 --format=%h) ${tags}"
+fi
 
 docker_login
-
-run docker build -t ${tagged} -t ${latest} .
-run docker push ${tagged}
-run docker push ${latest}
+for t in ${tags}; do
+	run docker build -t ${container}:${t}
+	run docker push ${container}:${t}
+done

--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -251,9 +251,18 @@ triggers:
       OTA_LITE_TAG: 'main'
       AKLITE_TAG: promoted-main
     runs:
+      - name: lmp-sdk-next
+        host-tag: amd64
+        container: foundries/dind-ci:19.03.9_b38f166
+        privileged: true
+        params:
+           LATEST=next
+        script-repo:
+          name: fio
+          path: lmp/build-sdk-container.sh
       # images with no OTA
       - name: "{loop}"
-        container: hub.foundries.io/lmp-sdk
+        container: hub.foundries.io/lmp-sdk:next
         host-tag: amd64-partner-gcp-nocache
         loop-on:
           - param: MACHINE
@@ -271,7 +280,7 @@ triggers:
 
       # mfgtool / uuu related build files
       - name: mfgtool-{loop}
-        container: hub.foundries.io/lmp-sdk
+        container: hub.foundries.io/lmp-sdk:next
         host-tag: amd64-partner-gcp-nocache
         loop-on:
           - param: MACHINE
@@ -296,7 +305,7 @@ triggers:
 
       # wayland distro flavor
       - name: build-lmp-wayland-{loop}
-        container: hub.foundries.io/lmp-sdk
+        container: hub.foundries.io/lmp-sdk:next
         host-tag: amd64-partner-gcp-nocache
         loop-on:
           - param: MACHINE


### PR DESCRIPTION
If the environment variable is present, use it as a tag when creating the container.
The default is build with the tag latest and also with the corresponding version tag.