### PR TITLE
lmp/jobserv: build-sdk-container: fix LATEST params

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -256,7 +256,7 @@ triggers:
         container: foundries/dind-ci:19.03.9_b38f166
         privileged: true
         params:
-           LATEST=next
+           LATEST: next
         script-repo:
           name: fio
           path: lmp/build-sdk-container.sh


### PR DESCRIPTION
Fix Value 'LATEST=next' is not a dict.