### PR TITLE
lmp/build-sdk-container: fixup docker build

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -27,6 +27,6 @@ fi
 
 docker_login
 for t in ${tags}; do
-	run docker build -t ${container}:${t}
+	run docker build -t ${container}:${t} .
 	run docker push ${container}:${t}
 done


### PR DESCRIPTION
Add the missing path argument.