### PR TITLE
lmp: Move to new docker-dind container

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -6,10 +6,9 @@ source $HERE/../helpers.sh
 LATEST=${LATEST:-latest}
 
 status Launching dockerd
-unset DOCKER_HOST
 /usr/local/bin/dockerd-entrypoint.sh --experimental --raw-logs >/archive/dockerd.log 2>&1 &
 for i in `seq 12` ; do
-	sleep 1
+	sleep 2
 	docker info >/dev/null 2>&1 && break
 	if [ $i = 12 ] ; then
 		status Timed out trying to connect to internal docker host

--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -148,7 +148,7 @@ triggers:
     runs:
       - name: lmp-sdk
         host-tag: amd64
-        container: foundries/dind-ci:19.03.9_b38f166
+        container: foundries/dind-ci:27.2.1_0a2cd6a
         privileged: true
         script-repo:
           name: fio
@@ -253,7 +253,7 @@ triggers:
     runs:
       - name: lmp-sdk-next
         host-tag: amd64
-        container: foundries/dind-ci:19.03.9_b38f166
+        container: foundries/dind-ci:27.2.1_0a2cd6a
         privileged: true
         params:
            LATEST: next


### PR DESCRIPTION
The move to 22.04 for the lmp-sdk container image requires us to be on a newer version of Docker to build that image. The new image:

 * includes the change to unset DOCKER_HOST
 * takes a little longer to start up