### PR TITLE
lmp/build-sdk-container: incrase the dockerd launch timeout

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -7,10 +7,10 @@ LATEST=${LATEST:-latest}
 
 status Launching dockerd
 /usr/local/bin/dockerd-entrypoint.sh --experimental --raw-logs >/archive/dockerd.log 2>&1 &
-for i in `seq 12` ; do
-	sleep 2
+for i in `seq 12 -1 0` ; do
+	sleep 5
 	docker info >/dev/null 2>&1 && break
-	if [ $i = 12 ] ; then
+	if [ $i = 0 ] ; then
 		status Timed out trying to connect to internal docker host
 		exit 1
 	fi


### PR DESCRIPTION
The current time is not enough as can be seen, so it is better to increase it to 60 seconds.

== 2025-05-27 21:12:51 Launching dockerd
== 2025-05-27 21:13:15 Timed out trying to connect to internal docker host