### PR TITLE
Revert "lmp/build-sdk-container: restore the timeout"

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -9,7 +9,7 @@ status Launching dockerd
 unset DOCKER_HOST
 /usr/local/bin/dockerd-entrypoint.sh --experimental --raw-logs >/archive/dockerd.log 2>&1 &
 for i in `seq 12 -1 0` ; do
-	sleep 1
+	sleep 5
 	docker info >/dev/null 2>&1 && break
 	if [ $i = 0 ] ; then
 		status Timed out trying to connect to internal docker host


### PR DESCRIPTION
This reverts commit 69fc5bf2e5747b7f822f9f7d54336e308ff67bef.

The current time is not enough so it is better to increase it again to 60 seconds.