### PR TITLE
lmp/build-sdk-container: refactor the timeout

### DIFF
--- a/lmp/build-sdk-container.sh
+++ b/lmp/build-sdk-container.sh
@@ -8,13 +8,13 @@ LATEST=${LATEST:-latest}
 status Launching dockerd
 unset DOCKER_HOST
 /usr/local/bin/dockerd-entrypoint.sh --experimental --raw-logs >/archive/dockerd.log 2>&1 &
-for i in `seq 12 -1 0` ; do
-	sleep 5
+for i in `seq 60 -1 0` ; do
 	docker info >/dev/null 2>&1 && break
 	if [ $i = 0 ] ; then
 		status Timed out trying to connect to internal docker host
 		exit 1
 	fi
+	sleep 1
 done
 
 container="hub.foundries.io/lmp-sdk"


### PR DESCRIPTION
Use the same timeout but exit as quick as possible