### PR TITLE
lmp/jobserv: main-next: drop qemuarm64-secureboot

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -319,7 +319,6 @@ triggers:
           - param: MACHINE
             values:
               - intel-corei7-64
-              - qemuarm64-secureboot
         params:
           IMAGE: lmp-base-console-image
           MFGTOOL_FLASH_IMAGE: lmp-base-console-image


### PR DESCRIPTION
The qemuarm64-secureboot is broken because of the fitimage so disable it until we get it working again.