### PR TITLE
lmp/build: expose qcomflash zip archives

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -232,8 +232,9 @@ if [ -d "${archive}" ] ; then
 	# Make the main img.gz and respective bmap file be in the root of the archive
 	mv ${archive}/other/lmp-*.wic.gz ${archive}/ || true
 	mv ${archive}/other/lmp-*.wic.bmap ${archive}/ || true
-	# Qcom targets use a qcomflash tarball
+	# Qcom targets use a qcomflash tarball or zip archive
 	mv ${archive}/other/lmp-*.qcomflash.tar.gz ${archive}/ || true
+	mv ${archive}/other/lmp-*.qcomflash.zip ${archive}/ || true
 	# NVIDIA targets use a tegraflash tarball
 	mv ${archive}/other/lmp-*.tegraflash.tar.gz ${archive}/ || true
 	# Telechips targets use a fai image


### PR DESCRIPTION
Previously we exposed qcomflash tarballs, however, we also support zip archives for customers who interact with Windows a lot and are seeing corruption.  Let's expose those files as well.