### PR TITLE
lmp: pr: add raspberrypi5

### DIFF
--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -366,6 +366,7 @@ triggers:
               - jetson-agx-orin-devkit
               - qemuarm64-secureboot
               - raspberrypi4-64
+              - raspberrypi5
         params:
           BITBAKE_EXTRA_ARGS: --continue
           IMAGE: lmp-base-console-image


### PR DESCRIPTION
Add raspberrypi5 to the pr machine list, as we now have the board available for wider testing.