### PR TITLE
lmp/build.sh: Make sure to fetch the tags

### DIFF
--- a/lmp/build.sh
+++ b/lmp/build.sh
@@ -16,6 +16,10 @@ if [[ $GIT_URL == *"/lmp-manifest.git"* ]]; then
 	manifest="file://$(pwd)/.git -b $GIT_SHA"
 	# repo init won't work off detached heads, so do this to work around:
 	git branch pr-branch $GIT_SHA
+	# fetch also the tags when we are in the CI
+	if [ -n "$GH_TARGET_REPO" ] && [ "$GH_TARGET_REPO" != "$GIT_URL" ]; then
+		git fetch "$GH_TARGET_REPO" --tags --quiet
+	fi
 	# Check to make sure REPO_INIT_OVERRIDES isn't setting a "-b <ref>".
 	# That will break our logic for checking out the exact GIT_SHA above
 	export REPO_INIT_OVERRIDES=$(echo $REPO_INIT_OVERRIDES | sed -e 's/-b\s*\S*//')

--- a/lmp/jobserv.yml
+++ b/lmp/jobserv.yml
@@ -398,4 +398,3 @@ params:
 script-repos:
   fio:
     clone-url: https://github.com/foundriesio/ci-scripts
-    git-ref: debug-branch


### PR DESCRIPTION
Fetch tags from GH_TARGET_REPO into the local clone before handing it off to repo init, so the tags are available in the setup-environment-internal context.

Fix the error on scarthgap:

```
  Saved manifest to /archive/manifest.pinned.xml
  == 2026-04-07 20:47:38 Base LmP cache version detected as: 97
  fatal: No names found, cannot describe anything.
  Script completed with error(s)
  == 2026-04-07 20:47:42.780281: Finding artifacts to upload
```